### PR TITLE
breaking(registry): change path

### DIFF
--- a/internal/boot/root.go
+++ b/internal/boot/root.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mistweaverco/zana-client/internal/lib/updater"
 )
 
-var DEFAULT_REGISTRY_URL = "https://github.com/mistweaverco/zana-registry/releases/latest/download/registry.json.zip"
+var DEFAULT_REGISTRY_URL = "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip"
 
 type errMsg error
 

--- a/internal/lib/files/root.go
+++ b/internal/lib/files/root.go
@@ -46,9 +46,9 @@ func GetTempPath() string {
 }
 
 // GetAppRegistryFilePath returns the path to the registry file
-// e.g. /home/user/.config/zana/registry.json
+// e.g. /home/user/.config/zana/zana-registry.json
 func GetAppRegistryFilePath() string {
-	return GetAppDataPath() + PS + "registry.json"
+	return GetAppDataPath() + PS + "zana-registry.json"
 }
 
 // GetAppPackagesPath returns the path to the packages directory


### PR DESCRIPTION
This is so that zana-client works with zana files and Mason can work with Mason specific files.