### PR TITLE
feat(cli): add sync subcommand

### DIFF
--- a/cmd/zana/root.go
+++ b/cmd/zana/root.go
@@ -53,6 +53,7 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(removeCmd)
+	rootCmd.AddCommand(syncCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Version, "version", false, "version")
 	rootCmd.PersistentFlags().DurationVar(&cfg.Flags.CacheMaxAge, "cache-max-age", 24*time.Hour, "maximum age of registry cache (e.g., 1h, 24h, 7d)")

--- a/cmd/zana/sync.go
+++ b/cmd/zana/sync.go
@@ -1,0 +1,86 @@
+package zana
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mistweaverco/zana-client/internal/lib/files"
+	"github.com/mistweaverco/zana-client/internal/lib/providers"
+	"github.com/spf13/cobra"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync registry or packages",
+	Long: `Sync registry or packages.
+
+The sync command has two subcommands:
+  registry  - Download and unzip the latest registry file
+  packages  - Ensure all packages in zana-lock.json are installed in exact versions`,
+}
+
+var syncRegistryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Download and unzip the latest registry file",
+	Long: `Download and unzip the latest registry file from the registry URL.
+
+This command downloads the registry file and extracts it to the app data directory.
+The registry URL can be overridden using the ZANA_REGISTRY_URL environment variable.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Downloading registry...")
+		if err := syncRegistryFn(); err != nil {
+			fmt.Printf("✗ Failed to sync registry: %v\n", err)
+			osExit(1)
+			return
+		}
+		fmt.Println("✓ Registry synced successfully")
+	},
+}
+
+var syncPackagesCmd = &cobra.Command{
+	Use:   "packages",
+	Short: "Sync all packages from zana-lock.json",
+	Long: `Ensure all packages defined in zana-lock.json are installed in the exact versions specified.
+
+This command reads the zana-lock.json file and ensures that all packages
+are installed with their exact versions as specified in the lock file.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Syncing packages from zana-lock.json...")
+		syncPackagesFn()
+		fmt.Println("✓ Packages sync completed")
+	},
+}
+
+func init() {
+	syncCmd.AddCommand(syncRegistryCmd)
+	syncCmd.AddCommand(syncPackagesCmd)
+}
+
+// downloadAndUnzipRegistryForced downloads and unzips the registry, forcing a fresh download
+func downloadAndUnzipRegistryForced() error {
+	registryURL := "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip"
+	if override := os.Getenv("ZANA_REGISTRY_URL"); override != "" {
+		registryURL = override
+	}
+
+	cachePath := files.GetRegistryCachePath()
+
+	// Force download by using 0 duration (cache is never valid)
+	if err := files.DownloadWithCache(registryURL, cachePath, 0); err != nil {
+		return fmt.Errorf("failed to download registry: %w", err)
+	}
+
+	// Unzip the registry
+	if err := files.Unzip(cachePath, files.GetAppDataPath()); err != nil {
+		return fmt.Errorf("failed to unzip registry: %w", err)
+	}
+
+	return nil
+}
+
+// indirections for testability
+var (
+	syncRegistryFn = downloadAndUnzipRegistryForced
+	syncPackagesFn = providers.SyncAll
+)
+


### PR DESCRIPTION
- zana sync registry -- downloads the latest registry info
- zana sync packages -- ensures all packages are installed according to zana-lock.json