### PR TITLE
feat(ux): simplify package ids

### DIFF
--- a/cmd/zana/completion.go
+++ b/cmd/zana/completion.go
@@ -1,0 +1,52 @@
+package zana
+
+import (
+	"strings"
+
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+	"github.com/spf13/cobra"
+)
+
+// displayPackageIDFromRegistryID converts an internal registry/source ID into
+// the user-facing format used on the CLI.
+//
+// Internal IDs are currently of the form:
+//
+//	pkg:<provider>/<package-id>
+//
+// and are exposed to users as:
+//
+//	<provider>:<package-id>
+func displayPackageIDFromRegistryID(sourceID string) string {
+	if strings.HasPrefix(sourceID, "pkg:") {
+		rest := strings.TrimPrefix(sourceID, "pkg:")
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) == 2 {
+			return parts[0] + ":" + parts[1]
+		}
+	}
+	return sourceID
+}
+
+// newRegistryParserFn is an indirection for tests.
+var newRegistryParserFn = registry_parser.NewDefaultRegistryParser
+
+// packageIDCompletion provides shell completion for package IDs based on the
+// locally available registry data.
+func packageIDCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	parser := newRegistryParserFn()
+	items := parser.GetData(false)
+
+	completions := make([]string, 0, len(items))
+	for _, item := range items {
+		displayID := displayPackageIDFromRegistryID(strings.TrimSpace(item.Source.ID))
+		if displayID == "" {
+			continue
+		}
+		if toComplete == "" || strings.HasPrefix(displayID, toComplete) {
+			completions = append(completions, displayID)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/zana/install.go
+++ b/cmd/zana/install.go
@@ -8,31 +8,85 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// validatePackageArgs validates the package arguments
+// parseUserPackageID parses a user-facing package ID and returns
+// the provider and raw package identifier (without version).
+//
+// It supports both the legacy format:
+//
+//	pkg:<provider>/<package-name>
+//
+// and the new simplified format:
+//
+//	<provider>:<package-name>
+func parseUserPackageID(arg string) (string, string, error) {
+	// Legacy format: pkg:provider/name
+	if strings.HasPrefix(arg, "pkg:") {
+		parts := strings.Split(strings.TrimPrefix(arg, "pkg:"), "/")
+		if len(parts) < 2 {
+			return "", "", fmt.Errorf("invalid package ID format '%s': expected 'pkg:provider/package-name[@version]'", arg)
+		}
+		provider := parts[0]
+		if provider == "" {
+			return "", "", fmt.Errorf("invalid package ID format '%s': provider cannot be empty", arg)
+		}
+		packageName := parts[1]
+		if packageName == "" {
+			return "", "", fmt.Errorf("invalid package ID format '%s': package name cannot be empty", arg)
+		}
+		return provider, packageName, nil
+	}
+
+	// New format: provider:package-name
+	if !strings.Contains(arg, ":") {
+		return "", "", fmt.Errorf("invalid package ID format '%s': expected '<provider>:<package-id>[@version]'", arg)
+	}
+
+	parts := strings.SplitN(arg, ":", 2)
+	provider := parts[0]
+	packageName := parts[1]
+
+	if provider == "" {
+		return "", "", fmt.Errorf("invalid package ID format '%s': provider cannot be empty", arg)
+	}
+	if packageName == "" {
+		return "", "", fmt.Errorf("invalid package ID format '%s': package id cannot be empty", arg)
+	}
+
+	return provider, packageName, nil
+}
+
+// toInternalPackageID normalizes a user-facing package ID to the
+// internal representation "<provider>:<package-id>".
+// This is the format used in zana-lock.json and throughout the codebase.
+func toInternalPackageID(provider, pkgID string) string {
+	return provider + ":" + pkgID
+}
+
+// normalizePackageID converts a package ID from legacy format (pkg:provider/pkg)
+// to the new format (provider:pkg), or returns it unchanged if already in new format.
+// This is used for backward compatibility when reading zana-lock.json.
+func normalizePackageID(sourceID string) string {
+	if strings.HasPrefix(sourceID, "pkg:") {
+		rest := strings.TrimPrefix(sourceID, "pkg:")
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) == 2 {
+			return parts[0] + ":" + parts[1]
+		}
+	}
+	return sourceID
+}
+
+// validatePackageArgs validates the package arguments (for cobra)
+// and ensures that all providers are supported.
 func validatePackageArgs(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("requires at least 1 argument")
 	}
 
 	for _, arg := range args {
-		if !strings.HasPrefix(arg, "pkg:") {
-			return fmt.Errorf("invalid package ID format '%s': must start with 'pkg:'", arg)
-		}
-
-		// Parse provider from package ID
-		parts := strings.Split(strings.TrimPrefix(arg, "pkg:"), "/")
-		if len(parts) < 2 {
-			return fmt.Errorf("invalid package ID format '%s': expected 'pkg:provider/package-name[@version]'", arg)
-		}
-
-		provider := parts[0]
-		if provider == "" {
-			return fmt.Errorf("invalid package ID format '%s': provider cannot be empty", arg)
-		}
-
-		packageName := parts[1]
-		if packageName == "" {
-			return fmt.Errorf("invalid package ID format '%s': package name cannot be empty", arg)
+		provider, _, err := parseUserPackageID(arg)
+		if err != nil {
+			return err
 		}
 
 		if !providers.IsSupportedProvider(provider) {
@@ -51,37 +105,48 @@ var installCmd = &cobra.Command{
 	Long: `Install one or more packages from supported providers.
 
 Supported package ID formats:
-  pkg:npm/@prisma/language-server
-  pkg:npm/@prisma/language-server@latest
-  pkg:golang/golang.org/x/tools/gopls@v0.14.0
-  pkg:pypi/black@22.3.0
-  pkg:cargo/ripgrep@13.0.0
+  npm:@prisma/language-server
+  npm:@prisma/language-server@latest
+  golang:golang.org/x/tools/gopls@v0.14.0
+  pypi:black@22.3.0
+  cargo:ripgrep@13.0.0
 
 Examples:
-  zana install pkg:npm/@prisma/language-server
-  zana install pkg:golang/golang.org/x/tools/gopls@latest
-  zana install pkg:npm/eslint pkg:pypi/black@22.3.0
-  zana install pkg:cargo/ripgrep@13.0.0 pkg:npm/prettier`,
+  zana install npm:@prisma/language-server
+  zana install golang:golang.org/x/tools/gopls@latest
+  zana install npm:eslint pypi:black@22.3.0
+  zana install cargo:ripgrep@13.0.0 npm:prettier`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		return validatePackageArgs(args)
 	},
+	// Enable shell completion for package IDs based on the local registry.
+	ValidArgsFunction: packageIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Install all packages
 		successCount := 0
 		failureCount := 0
 		var failures []string
 
-		for _, pkgId := range args {
-			// Parse package ID and version
-			pkgId, version := parsePackageIDAndVersion(pkgId)
+		for _, userPkgID := range args {
+			// Parse package ID and version from the user-facing ID
+			baseID, version := parsePackageIDAndVersion(userPkgID)
+			provider, pkgName, err := parseUserPackageID(baseID)
+			if err != nil {
+				// This shouldn't happen because Args validation already ran,
+				// but guard just in case.
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
 
-			if installPackageFn(pkgId, version) {
+			internalID := toInternalPackageID(provider, pkgName)
+
+			if installPackageFn(internalID, version) {
 				successCount++
-				fmt.Printf("✓ Successfully installed %s@%s\n", pkgId, version)
+				fmt.Printf("✓ Successfully installed %s@%s\n", userPkgID, version)
 			} else {
 				failureCount++
-				failures = append(failures, pkgId)
-				fmt.Printf("✗ Failed to install %s@%s\n", pkgId, version)
+				failures = append(failures, userPkgID)
+				fmt.Printf("✗ Failed to install %s@%s\n", userPkgID, version)
 			}
 		}
 

--- a/cmd/zana/list.go
+++ b/cmd/zana/list.go
@@ -262,6 +262,17 @@ func checkUpdateAvailability(sourceID, currentVersion string) (string, bool) {
 }
 
 func getProviderFromSourceID(sourceID string) string {
+	// Support both legacy (pkg:provider/pkg) and new (provider:pkg) formats
+	if strings.HasPrefix(sourceID, "npm:") {
+		return "npm"
+	} else if strings.HasPrefix(sourceID, "golang:") {
+		return "golang"
+	} else if strings.HasPrefix(sourceID, "pypi:") {
+		return "pypi"
+	} else if strings.HasPrefix(sourceID, "cargo:") {
+		return "cargo"
+	}
+	// Legacy format support
 	if strings.HasPrefix(sourceID, "pkg:npm/") {
 		return "npm"
 	} else if strings.HasPrefix(sourceID, "pkg:golang/") {
@@ -275,13 +286,18 @@ func getProviderFromSourceID(sourceID string) string {
 }
 
 func getPackageNameFromSourceID(sourceID string) string {
-	// Remove the "pkg:" prefix
+	// Support new format: provider:pkg
+	if strings.Contains(sourceID, ":") && !strings.HasPrefix(sourceID, "pkg:") {
+		parts := strings.SplitN(sourceID, ":", 2)
+		if len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	// Legacy format: pkg:provider/pkg
 	withoutPrefix := strings.TrimPrefix(sourceID, "pkg:")
-
-	// Split by "/" to separate provider from package name
 	parts := strings.SplitN(withoutPrefix, "/", 2)
 	if len(parts) >= 2 {
-		return parts[1] // Return everything after the first "/"
+		return parts[1]
 	}
 	return sourceID
 }

--- a/internal/lib/providers/cargo_provider.go
+++ b/internal/lib/providers/cargo_provider.go
@@ -42,12 +42,18 @@ func NewProviderCargo() *CargoProvider {
 	p := &CargoProvider{}
 	p.PROVIDER_NAME = "cargo"
 	p.APP_PACKAGES_DIR = filepath.Join(files.GetAppPackagesPath(), p.PROVIDER_NAME)
-	p.PREFIX = "pkg:" + p.PROVIDER_NAME + "/"
+	p.PREFIX = p.PROVIDER_NAME + ":"
 	return p
 }
 
 func (p *CargoProvider) getRepo(sourceID string) string {
-	re := regexp.MustCompile("^" + p.PREFIX + "(.*)")
+	// Support both legacy (pkg:cargo/pkg) and new (cargo:pkg) formats
+	normalized := normalizePackageID(sourceID)
+	if strings.HasPrefix(normalized, p.PREFIX) {
+		return strings.TrimPrefix(normalized, p.PREFIX)
+	}
+	// Fallback for legacy format
+	re := regexp.MustCompile("^pkg:" + p.PROVIDER_NAME + "/(.*)")
 	matches := re.FindStringSubmatch(sourceID)
 	if len(matches) > 1 {
 		return matches[1]

--- a/internal/lib/providers/golang_provider.go
+++ b/internal/lib/providers/golang_provider.go
@@ -40,12 +40,18 @@ func NewProviderGolang() *GolangProvider {
 	p := &GolangProvider{}
 	p.PROVIDER_NAME = "golang"
 	p.APP_PACKAGES_DIR = filepath.Join(files.GetAppPackagesPath(), p.PROVIDER_NAME)
-	p.PREFIX = "pkg:" + p.PROVIDER_NAME + "/"
+	p.PREFIX = p.PROVIDER_NAME + ":"
 	return p
 }
 
 func (p *GolangProvider) getRepo(sourceID string) string {
-	re := regexp.MustCompile("^" + p.PREFIX + "(.*)")
+	// Support both legacy (pkg:golang/pkg) and new (golang:pkg) formats
+	normalized := normalizePackageID(sourceID)
+	if strings.HasPrefix(normalized, p.PREFIX) {
+		return strings.TrimPrefix(normalized, p.PREFIX)
+	}
+	// Fallback for legacy format
+	re := regexp.MustCompile("^pkg:" + p.PROVIDER_NAME + "/(.*)")
 	matches := re.FindStringSubmatch(sourceID)
 	if len(matches) > 1 {
 		return matches[1]

--- a/internal/lib/providers/npm_provider.go
+++ b/internal/lib/providers/npm_provider.go
@@ -44,12 +44,18 @@ func NewProviderNPM() *NPMProvider {
 	p := &NPMProvider{}
 	p.PROVIDER_NAME = "npm"
 	p.APP_PACKAGES_DIR = filepath.Join(files.GetAppPackagesPath(), p.PROVIDER_NAME)
-	p.PREFIX = "pkg:" + p.PROVIDER_NAME + "/"
+	p.PREFIX = p.PROVIDER_NAME + ":"
 	return p
 }
 
 func (p *NPMProvider) getRepo(sourceID string) string {
-	re := regexp.MustCompile("^" + p.PREFIX + "(.*)")
+	// Support both legacy (pkg:npm/pkg) and new (npm:pkg) formats
+	normalized := normalizePackageID(sourceID)
+	if strings.HasPrefix(normalized, p.PREFIX) {
+		return strings.TrimPrefix(normalized, p.PREFIX)
+	}
+	// Fallback for legacy format
+	re := regexp.MustCompile("^pkg:" + p.PROVIDER_NAME + "/(.*)")
 	matches := re.FindStringSubmatch(sourceID)
 	if len(matches) > 1 {
 		return matches[1]

--- a/internal/ui/root.go
+++ b/internal/ui/root.go
@@ -319,8 +319,17 @@ func getLocalPackagesData() []localPackageItem {
 	return localItems
 }
 
-// deriveNameFromSourceID extracts the package name from a sourceId like "pkg:cargo/ripgrep"
+// deriveNameFromSourceID extracts the package name from a sourceId.
+// Supports both legacy format (pkg:cargo/ripgrep) and new format (cargo:ripgrep).
 func deriveNameFromSourceID(sourceID string) string {
+	// Support new format: provider:pkg
+	if strings.Contains(sourceID, ":") && !strings.HasPrefix(sourceID, "pkg:") {
+		parts := strings.SplitN(sourceID, ":", 2)
+		if len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	// Legacy format: pkg:provider/pkg
 	withoutPrefix := strings.TrimPrefix(sourceID, "pkg:")
 	parts := strings.SplitN(withoutPrefix, "/", 2)
 	if len(parts) == 2 {

--- a/zana.schema.json
+++ b/zana.schema.json
@@ -12,7 +12,7 @@
         "properties": {
           "source_id": {
             "type": "string",
-            "pattern": "^pkg:(github|npm)/.+$"
+            "pattern": "^(npm|pypi|golang|cargo):.+$|^pkg:(github|npm|pypi|golang|cargo)/.+$"
           },
           "version": {
             "type": "string",


### PR DESCRIPTION
THIS IS A BREAKING CHANGE!

We try to be backwards compatible, but who knows?

The old format was quite verbose:

```
pkg:provider/packageid
```

The new format is quite elegant:

```
provider:packageid
```