### PR TITLE
feat(tree-sitter): Add Tree-sitter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ grab it directtly from the [releases][latest-release].
 The heart of Zana is its `zana-lock.json` file.
 This file is used to keep track of the installed packages and their versions.
 
-You can tell Zana where to find the `zana-lock.json` and
-the packages by setting the environment variable `ZANA_HOME`.
+You can tell Zana where to find the `zana-lock.json` (and optional `config.yaml`)
+by setting the environment variable `ZANA_HOME`.
 
 If `ZANA_HOME` isn't set,
 Zana will look for the `zana-lock.json` file in the default locations:
@@ -99,6 +99,15 @@ Zana will look for the `zana-lock.json` file in the default locations:
 
 If the file doesn't exist,
 Zana will create it for you (when you install a package).
+
+Zana's cache directory is controlled separately via `ZANA_CACHE`.
+If `ZANA_CACHE` is not set, Zana uses OS defaults:
+
+```
+- Linux: `~/.cache/zana`
+- macOS: `~/Library/Caches/zana`
+- Windows: `%LOCALAPPDATA%\zana\cache`
+```
 
 It's advised to keep the `zana-lock.json` file in version control.
 
@@ -234,6 +243,9 @@ The optional `config.yaml` lives next to `zana-lock.json` in your Zana config di
 Example:
 
 ```yaml
+paths:
+  # optional: cache directory (overridden by $ZANA_CACHE if set)
+  cacheDir: ~/.cache/zana
 registry:
   cacheMaxAge: 6h
   # url: https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip
@@ -327,10 +339,7 @@ zana health
 
 Zana uses a basepath to install packages of different types.
 
-If you have set the `ZANA_HOME` environment variable,
-the basepath will be `$ZANA_HOME/packages`.
-
-If `ZANA_HOME` isn't set, the basepath is:
+The basepath is:
 
 - Linux: `$XDG_DATA_HOME/zana/packages` or `$HOME/.local/share/zana/packages`
 - macOS: `$HOME/Library/Application Support/zana/packages`
@@ -341,6 +350,37 @@ The packages are installed in the following directory structure:
 ```
 $basepath/$provider/$package-name/
 ```
+
+### Tree-sitter parsers for Neovim
+
+Parsers are written to Neovim's data directory under:
+
+```
+<stdpath("data")>/site/parser/<language>.<so|dylib|dll>
+```
+
+Zana builds parsers from upstream source using the `tree-sitter` CLI when a
+registry package declares `treesitter.build`.
+
+By default, Zana only builds and caches the parser artifacts under:
+
+```
+<zana-data-share>/artifacts/treesitter/<package>/<version>/<language>.<so|dylib|dll>
+```
+
+To install built parsers into Neovim, use:
+
+```sh
+zana install --integrate neovim <package>
+```
+
+Zana resolves `<stdpath("data")>` by running Neovim headless when available
+(`nvim --headless ...`). If `nvim` is not available, it falls back to common
+defaults:
+
+- Linux: `$XDG_DATA_HOME/nvim` or `~/.local/share/nvim`
+- macOS: `~/Library/Application Support/nvim`
+- Windows: `%LOCALAPPDATA%\\nvim-data`
 
 ## Supported providers
 

--- a/cmd/zana/install.go
+++ b/cmd/zana/install.go
@@ -126,6 +126,9 @@ Examples:
 	// Enable shell completion for package IDs based on the local registry.
 	ValidArgsFunction: packageIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Configure optional integrations (editor backends).
+		providers.SetRequestedIntegrations(installIntegrations)
+
 		// Install all packages
 		successCount := 0
 		failureCount := 0
@@ -228,6 +231,9 @@ Examples:
 					if success {
 						successCount++
 						fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
+						for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
+							fmt.Printf("  %s\n", line)
+						}
 					} else {
 						failureCount++
 						failures = append(failures, displayID)
@@ -277,6 +283,9 @@ Examples:
 			if success {
 				successCount++
 				fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
+				for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
+					fmt.Printf("  %s\n", line)
+				}
 			} else {
 				failureCount++
 				failures = append(failures, displayID)
@@ -302,6 +311,12 @@ Examples:
 			}
 		}
 	},
+}
+
+var installIntegrations []string
+
+func init() {
+	installCmd.Flags().StringSliceVar(&installIntegrations, "integrate", nil, "run integration backends after install (e.g. --integrate neovim)")
 }
 
 // indirections for testability

--- a/cmd/zana/remove.go
+++ b/cmd/zana/remove.go
@@ -35,6 +35,10 @@ Examples:
 	// Enable shell completion for installed package IDs only.
 	ValidArgsFunction: installedPackageIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Configure optional integrations (editor backends).
+		// This matters for cleanup (e.g. removing Neovim parser libs).
+		providers.SetRequestedIntegrations(removeIntegrations)
+
 		packages := args
 
 		// Process all packages
@@ -147,6 +151,12 @@ Examples:
 			}
 		}
 	},
+}
+
+var removeIntegrations []string
+
+func init() {
+	removeCmd.Flags().StringSliceVar(&removeIntegrations, "integrate", nil, "run integration backends cleanup when removing (e.g. --integrate neovim)")
 }
 
 // findInstalledPackagesByName searches installed packages for packages matching the given name

--- a/cmd/zana/sync.go
+++ b/cmd/zana/sync.go
@@ -2,9 +2,7 @@ package zana
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/charmbracelet/huh/spinner"
 	"github.com/mistweaverco/zana-client/internal/lib/files"
 	"github.com/mistweaverco/zana-client/internal/lib/providers"
 	"github.com/spf13/cobra"
@@ -85,33 +83,7 @@ func init() {
 
 // downloadAndUnzipRegistryForced downloads and unzips the registry, forcing a fresh download
 func downloadAndUnzipRegistryForced() error {
-	registryURL := "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip"
-	if override := os.Getenv("ZANA_REGISTRY_URL"); override != "" {
-		registryURL = override
-	}
-
-	cachePath := files.GetRegistryCachePath()
-
-	// Force download by using 0 duration (cache is never valid) with spinner
-	var downloadErr error
-	action := func() {
-		downloadErr = files.DownloadWithCache(registryURL, cachePath, 0)
-	}
-
-	if err := spinner.New().Title("Downloading registry...").Action(action).Run(); err != nil {
-		return err
-	}
-
-	if downloadErr != nil {
-		return fmt.Errorf("failed to download registry: %w", downloadErr)
-	}
-
-	// Unzip the registry to the cache directory
-	if err := files.Unzip(cachePath, files.GetCachePath()); err != nil {
-		return fmt.Errorf("failed to unzip registry: %w", err)
-	}
-
-	return nil
+	return files.DownloadAndUnzipRegistryForced()
 }
 
 // indirections for testability

--- a/internal/config/file_config.go
+++ b/internal/config/file_config.go
@@ -16,6 +16,10 @@ type FileConfig struct {
 		CacheMaxAge string `yaml:"cacheMaxAge"`
 	} `yaml:"registry"`
 
+	Paths struct {
+		CacheDir string `yaml:"cacheDir"`
+	} `yaml:"paths"`
+
 	UI struct {
 		Color  string `yaml:"color"`
 		Output string `yaml:"output"`

--- a/internal/lib/files/path_functions_test.go
+++ b/internal/lib/files/path_functions_test.go
@@ -56,6 +56,57 @@ func TestPathFunctions(t *testing.T) {
 
 // TestPathFunctionsComprehensive tests comprehensive path scenarios
 func TestPathFunctionsComprehensive(t *testing.T) {
+	t.Run("get cache path precedence env over config", func(t *testing.T) {
+		mockFS := &MockFileSystem{
+			fs: afero.NewMemMapFs(),
+			GetenvFunc: func(key string) string {
+				if key == "ZANA_HOME" {
+					return "/cfg"
+				}
+				if key == "ZANA_CACHE" {
+					return "/envcache"
+				}
+				return ""
+			},
+			UserHomeDirFunc: func() (string, error) { return "/home/user", nil },
+			UserConfigDirFunc: func() (string, error) {
+				return "/home/user/.config", nil
+			},
+		}
+		SetFileSystem(mockFS)
+		defer ResetDependencies()
+
+		// Even if config.yaml requests a different cache dir, env var must win.
+		_ = mockFS.fs.MkdirAll("/cfg", 0o755)
+		_ = afero.WriteFile(mockFS.fs, "/cfg/config.yaml", []byte("paths:\n  cacheDir: /cfgcache\n"), 0o644)
+
+		assert.Equal(t, "/envcache", GetCachePath())
+	})
+
+	t.Run("get cache path uses config when env not set", func(t *testing.T) {
+		mockFS := &MockFileSystem{
+			fs: afero.NewMemMapFs(),
+			GetenvFunc: func(key string) string {
+				if key == "ZANA_HOME" {
+					return "/cfg"
+				}
+				return ""
+			},
+			UserHomeDirFunc: func() (string, error) { return "/home/user", nil },
+			UserConfigDirFunc: func() (string, error) {
+				return "/home/user/.config", nil
+			},
+		}
+		SetFileSystem(mockFS)
+		defer ResetDependencies()
+
+		_ = mockFS.fs.MkdirAll("/cfg", 0o755)
+		_ = afero.WriteFile(mockFS.fs, "/cfg/config.yaml", []byte("paths:\n  cacheDir: rel/cache\n"), 0o644)
+
+		// relative paths should be resolved relative to $HOME
+		assert.Equal(t, "/home/user/rel/cache", GetCachePath())
+	})
+
 	t.Run("get app data path with ZANA_HOME set", func(t *testing.T) {
 		// Create an in-memory filesystem for testing
 		mockFS := &MockFileSystem{

--- a/internal/lib/files/root.go
+++ b/internal/lib/files/root.go
@@ -227,30 +227,21 @@ func GetAppRegistryFilePath() string {
 }
 
 // GetAppPackagesPath returns the path to the packages directory
-// If ZANA_HOME is set, it will use $ZANA_HOME/packages
 // Otherwise:
 //   - Linux: ~/.local/share/zana/packages
 //   - macOS: ~/Library/Application Support/zana/packages
 //   - Windows: %APPDATA%\zana\packages
 func GetAppPackagesPath() string {
-	if zanaHome := fileSystem.Getenv("ZANA_HOME"); zanaHome != "" {
-		return EnsureDirExists(zanaHome + string(os.PathSeparator) + "packages")
-	}
 	return EnsureDirExists(GetAppDataSharePath() + string(os.PathSeparator) + "packages")
 }
 
 // GetAppDataSharePath returns the path to the app data share directory
 // This is separate from the config directory and follows XDG Base Directory spec
-// If ZANA_HOME is set, it will use that path
 // Otherwise:
 //   - Linux: ~/.local/share/zana
 //   - macOS: ~/Library/Application Support/zana (same as config)
 //   - Windows: %APPDATA%\zana (same as config)
 func GetAppDataSharePath() string {
-	if zanaHome := fileSystem.Getenv("ZANA_HOME"); zanaHome != "" {
-		return EnsureDirExists(zanaHome)
-	}
-
 	// On Linux, use ~/.local/share, otherwise use config dir (macOS/Windows)
 	userConfigDir, err := fileSystem.UserConfigDir()
 	if err != nil {
@@ -273,7 +264,6 @@ func GetAppDataSharePath() string {
 }
 
 // GetAppBinPath returns the path to the bin directory
-// If ZANA_HOME is set, it will use $ZANA_HOME/bin
 // Otherwise:
 //   - Linux: ~/.local/share/zana/bin
 //   - macOS: ~/Library/Application Support/zana/bin
@@ -281,9 +271,6 @@ func GetAppDataSharePath() string {
 //
 // e.g. /home/user/.local/share/zana/bin
 func GetAppBinPath() string {
-	if zanaHome := fileSystem.Getenv("ZANA_HOME"); zanaHome != "" {
-		return EnsureDirExists(zanaHome + string(os.PathSeparator) + "bin")
-	}
 	return EnsureDirExists(GetAppDataSharePath() + string(os.PathSeparator) + "bin")
 }
 
@@ -376,6 +363,12 @@ func Unzip(src, dest string) error {
 func GetCachePath() string {
 	if zanaCache := fileSystem.Getenv("ZANA_CACHE"); zanaCache != "" {
 		return EnsureDirExists(zanaCache)
+	}
+
+	if cfg, ok := readZanaConfigFile(); ok {
+		if raw := strings.TrimSpace(cfg.Paths.CacheDir); raw != "" {
+			return EnsureDirExists(expandUserAndRelativePath(raw))
+		}
 	}
 
 	userHomeDir, err := fileSystem.UserHomeDir()
@@ -472,6 +465,38 @@ type zanaConfigFile struct {
 		URL         string `yaml:"url"`
 		CacheMaxAge string `yaml:"cacheMaxAge"`
 	} `yaml:"registry"`
+
+	Paths struct {
+		CacheDir string `yaml:"cacheDir"`
+	} `yaml:"paths"`
+}
+
+func expandUserAndRelativePath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+
+	// Expand "~" to the user's home directory.
+	if p == "~" || strings.HasPrefix(p, "~"+string(os.PathSeparator)) {
+		home, err := fileSystem.UserHomeDir()
+		if err == nil && home != "" {
+			if p == "~" {
+				return home
+			}
+			return filepath.Join(home, strings.TrimPrefix(p, "~"+string(os.PathSeparator)))
+		}
+	}
+
+	// If relative, make it relative to the user's home directory (safer than cwd).
+	if !filepath.IsAbs(p) {
+		home, err := fileSystem.UserHomeDir()
+		if err == nil && home != "" {
+			return filepath.Join(home, p)
+		}
+	}
+
+	return p
 }
 
 func getConfigFilePath() string {
@@ -517,20 +542,23 @@ func getRegistryCacheMaxAge() time.Duration {
 	return maxAge
 }
 
+func resolveRegistryURL() string {
+	registryURL := "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip"
+	if override := fileSystem.Getenv("ZANA_REGISTRY_URL"); strings.TrimSpace(override) != "" {
+		return strings.TrimSpace(override)
+	}
+	if cfg, ok := readZanaConfigFile(); ok {
+		if u := strings.TrimSpace(cfg.Registry.URL); u != "" {
+			return u
+		}
+	}
+	return registryURL
+}
+
 // DownloadAndUnzipRegistry downloads the registry from the default URL and unzips it
 // This is used to ensure the registry is available for commands that need it
 func DownloadAndUnzipRegistry() error {
-	registryURL := "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip"
-	if override := fileSystem.Getenv("ZANA_REGISTRY_URL"); override != "" {
-		registryURL = override
-	}
-	if registryURL == "https://github.com/mistweaverco/zana-registry/releases/latest/download/zana-registry.json.zip" {
-		if cfg, ok := readZanaConfigFile(); ok {
-			if u := strings.TrimSpace(cfg.Registry.URL); u != "" {
-				registryURL = u
-			}
-		}
-	}
+	registryURL := resolveRegistryURL()
 
 	cachePath := GetRegistryCachePath()
 	registryJSONPath := GetAppRegistryFilePath()
@@ -561,6 +589,35 @@ func DownloadAndUnzipRegistry() error {
 	var downloadErr error
 	action := func() {
 		downloadErr = DownloadWithCache(registryURL, cachePath, cacheMaxAge)
+	}
+
+	if err := spinner.New().Title("Downloading registry...").Action(action).Run(); err != nil {
+		return err
+	}
+
+	if downloadErr != nil {
+		return fmt.Errorf("failed to download registry: %w", downloadErr)
+	}
+
+	// Unzip the registry to the cache directory
+	if err := Unzip(cachePath, GetCachePath()); err != nil {
+		return fmt.Errorf("failed to unzip registry: %w", err)
+	}
+
+	return nil
+}
+
+// DownloadAndUnzipRegistryForced is like DownloadAndUnzipRegistry, but always forces a fresh download.
+// It still respects registry URL resolution (ZANA_REGISTRY_URL > config.yaml > default).
+func DownloadAndUnzipRegistryForced() error {
+	registryURL := resolveRegistryURL()
+
+	cachePath := GetRegistryCachePath()
+
+	// Force download by using 0 duration (cache is never valid) with spinner
+	var downloadErr error
+	action := func() {
+		downloadErr = DownloadWithCache(registryURL, cachePath, 0)
 	}
 
 	if err := spinner.New().Title("Downloading registry...").Action(action).Run(); err != nil {

--- a/internal/lib/providers/generic_provider.go
+++ b/internal/lib/providers/generic_provider.go
@@ -172,6 +172,13 @@ func (p *GenericProvider) Remove(sourceID string) bool {
 		return false
 	}
 
+	// Remove Neovim tree-sitter parser(s) if this package installed them.
+	registry := genericRegistryParser()
+	registryItem := registry.GetBySourceId(sourceID)
+	if err := removeNeovimTreeSitterParsers(registryItem); err != nil {
+		Logger.Info(fmt.Sprintf("Generic Remove: Warning removing Neovim tree-sitter parsers: %v", err))
+	}
+
 	Logger.Info(fmt.Sprintf("Generic Remove: Removing %s", packageName))
 
 	packageDir := filepath.Join(p.APP_PACKAGES_DIR, packageName)

--- a/internal/lib/providers/github_provider.go
+++ b/internal/lib/providers/github_provider.go
@@ -216,6 +216,8 @@ func (p *GitHubProvider) installFromGit(sourceID, repo, version string) bool {
 
 	repoPath := p.getRepoPath(repo)
 	repoURL := p.getRepoURL(repo)
+	registry := githubRegistryParser()
+	registryItem := registry.GetBySourceId(sourceID)
 
 	// Ensure packages directory exists
 	if err := githubMkdir(p.APP_PACKAGES_DIR, 0755); err != nil && !os.IsExist(err) {
@@ -262,6 +264,12 @@ func (p *GitHubProvider) installFromGit(sourceID, repo, version string) bool {
 		return false
 	}
 
+	// If this is a Tree-sitter parser package, build artifacts and run requested integrations.
+	if err := buildAndMaybeIntegrateTreeSitter(repoPath, registryItem, resolvedVersion); err != nil {
+		Logger.Error(fmt.Sprintf("GitHub Install: Error building tree-sitter parsers: %v", err))
+		return false
+	}
+
 	// Add to local packages
 	if err := lppGithubAdd(sourceID, resolvedVersion); err != nil {
 		Logger.Error(fmt.Sprintf("GitHub Install: Error adding package to local packages: %v", err))
@@ -283,6 +291,13 @@ func (p *GitHubProvider) Remove(sourceID string) bool {
 	if repo == "" {
 		Logger.Error("GitHub Remove: Invalid source ID format")
 		return false
+	}
+
+	// Remove Neovim tree-sitter parser(s) if this package installed them.
+	registry := githubRegistryParser()
+	registryItem := registry.GetBySourceId(sourceID)
+	if err := removeNeovimTreeSitterParsers(registryItem); err != nil {
+		Logger.Info(fmt.Sprintf("GitHub Remove: Warning removing Neovim tree-sitter parsers: %v", err))
 	}
 
 	repoPath := p.getRepoPath(repo)

--- a/internal/lib/providers/integration_report.go
+++ b/internal/lib/providers/integration_report.go
@@ -1,0 +1,31 @@
+package providers
+
+import "strings"
+
+// integrationReports is a best-effort side-channel for the CLI to display
+// where integrations installed things.
+// Key format: "<sourceID>@<version>"
+var integrationReports = map[string][]string{}
+
+func integrationReportKey(sourceID, version string) string {
+	return strings.TrimSpace(sourceID) + "@" + strings.TrimSpace(version)
+}
+
+func AddIntegrationReportLine(sourceID, version, line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	k := integrationReportKey(sourceID, version)
+	integrationReports[k] = append(integrationReports[k], line)
+}
+
+// ConsumeIntegrationReport exposes per-install integration messages for the CLI.
+// It is best-effort; when no integrations ran, it returns nil/empty.
+func ConsumeIntegrationReport(sourceID, version string) []string {
+	k := integrationReportKey(sourceID, version)
+	lines := integrationReports[k]
+	delete(integrationReports, k)
+	return lines
+}
+

--- a/internal/lib/providers/integration_report_test.go
+++ b/internal/lib/providers/integration_report_test.go
@@ -1,0 +1,16 @@
+package providers
+
+import "testing"
+
+func TestIntegrationReport_Consume(t *testing.T) {
+	AddIntegrationReportLine("github:x/y", "v1", "Integrated into Neovim: /tmp")
+	lines := ConsumeIntegrationReport("github:x/y", "v1")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %#v", lines)
+	}
+	again := ConsumeIntegrationReport("github:x/y", "v1")
+	if len(again) != 0 {
+		t.Fatalf("expected empty after consume, got %#v", again)
+	}
+}
+

--- a/internal/lib/providers/integrations.go
+++ b/internal/lib/providers/integrations.go
@@ -1,0 +1,31 @@
+package providers
+
+import "strings"
+
+// integrations requested by the CLI layer (e.g. ["neovim"]).
+var requestedIntegrations []string
+
+func SetRequestedIntegrations(integrations []string) {
+	requestedIntegrations = nil
+	for _, i := range integrations {
+		i = strings.ToLower(strings.TrimSpace(i))
+		if i == "" {
+			continue
+		}
+		requestedIntegrations = append(requestedIntegrations, i)
+	}
+}
+
+func integrationEnabled(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	for _, i := range requestedIntegrations {
+		if i == name {
+			return true
+		}
+	}
+	return false
+}
+

--- a/internal/lib/providers/integrations_test.go
+++ b/internal/lib/providers/integrations_test.go
@@ -1,0 +1,14 @@
+package providers
+
+import "testing"
+
+func TestIntegrations_Enabled(t *testing.T) {
+	SetRequestedIntegrations([]string{"Neovim"})
+	if !integrationEnabled("neovim") {
+		t.Fatalf("expected neovim enabled")
+	}
+	if integrationEnabled("emacs") {
+		t.Fatalf("expected emacs disabled")
+	}
+}
+

--- a/internal/lib/providers/neovim_treesitter.go
+++ b/internal/lib/providers/neovim_treesitter.go
@@ -1,0 +1,152 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/shell_out"
+)
+
+// Injectable helpers for tests
+var (
+	neovimShellOutCapture = shell_out.ShellOutCapture
+	neovimMkdirAll        = os.MkdirAll
+	neovimRemove          = os.Remove
+	neovimUserHomeDir     = os.UserHomeDir
+	neovimGetenv          = os.Getenv
+	neovimReadFile        = os.ReadFile
+	neovimWriteFile       = os.WriteFile
+)
+
+func detectNeovimDataPath() (string, error) {
+	// Prefer Neovim itself: this respects OS + user overrides.
+	if code, out, err := neovimShellOutCapture("nvim", []string{
+		"--headless",
+		"+lua io.write(vim.fn.stdpath('data'))",
+		"+q",
+	}, "", nil); err == nil && code == 0 {
+		p := strings.TrimSpace(out)
+		if p != "" {
+			return p, nil
+		}
+	}
+
+	home, err := neovimUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		if xdg := strings.TrimSpace(neovimGetenv("XDG_DATA_HOME")); xdg != "" {
+			return filepath.Join(xdg, "nvim"), nil
+		}
+		return filepath.Join(home, ".local", "share", "nvim"), nil
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "nvim"), nil
+	case "windows":
+		// Neovim uses $LOCALAPPDATA/nvim-data by default.
+		if local := strings.TrimSpace(neovimGetenv("LOCALAPPDATA")); local != "" {
+			return filepath.Join(local, "nvim-data"), nil
+		}
+		// Fallback: best-effort.
+		return filepath.Join(home, "AppData", "Local", "nvim-data"), nil
+	default:
+		// Best-effort fallback.
+		return filepath.Join(home, ".local", "share", "nvim"), nil
+	}
+}
+
+func installNeovimParsersFromCache(sourceID, version string, languages []string) error {
+	if !integrationEnabled("neovim") {
+		return nil
+	}
+	dataDir, err := detectNeovimDataPath()
+	if err != nil {
+		return fmt.Errorf("detect neovim data path: %w", err)
+	}
+	destDir := filepath.Join(dataDir, "site", "parser")
+	if err := neovimMkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("create neovim parser dir: %w", err)
+	}
+
+	for _, lang := range languages {
+		lang = strings.TrimSpace(lang)
+		if lang == "" {
+			continue
+		}
+		srcPath := TreeSitterArtifactPath(sourceID, version, lang)
+		b, err := neovimReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("read built parser %s: %w", lang, err)
+		}
+		destPath := filepath.Join(destDir, lang+SharedLibExt())
+		if err := neovimWriteFile(destPath, b, 0o755); err != nil {
+			return fmt.Errorf("write neovim parser %s: %w", lang, err)
+		}
+	}
+
+	AddIntegrationReportLine(sourceID, version, fmt.Sprintf("Integrated into Neovim: %s", destDir))
+	return nil
+}
+
+func buildAndMaybeIntegrateTreeSitter(repoPath string, registryItem registry_parser.RegistryItem, version string) error {
+	if !IsTreeSitterCategory(registryItem.Categories) {
+		return nil
+	}
+	if registryItem.TreeSitter == nil || len(registryItem.TreeSitter.Build) == 0 {
+		return nil
+	}
+
+	langs, err := BuildTreeSitterParsersToCache(repoPath, registryItem.Source.ID, version, registryItem.TreeSitter.Build)
+	if err != nil {
+		return err
+	}
+	return installNeovimParsersFromCache(registryItem.Source.ID, version, langs)
+}
+
+func removeNeovimTreeSitterParsers(registryItem registry_parser.RegistryItem) error {
+	if !integrationEnabled("neovim") {
+		return nil
+	}
+	if !IsTreeSitterCategory(registryItem.Categories) {
+		return nil
+	}
+	if registryItem.TreeSitter == nil {
+		return nil
+	}
+	if len(registryItem.TreeSitter.Build) == 0 {
+		return nil
+	}
+
+	dataDir, err := detectNeovimDataPath()
+	if err != nil {
+		return fmt.Errorf("detect neovim data path: %w", err)
+	}
+
+	destDir := filepath.Join(dataDir, "site", "parser")
+	exts := []string{".so", ".dylib", ".dll"}
+
+	langs := map[string]struct{}{}
+	for _, b := range registryItem.TreeSitter.Build {
+		if strings.TrimSpace(b.Language) != "" {
+			langs[strings.TrimSpace(b.Language)] = struct{}{}
+		}
+	}
+
+	for lang := range langs {
+		lang = strings.TrimSpace(lang)
+		if lang == "" {
+			continue
+		}
+		for _, ext := range exts {
+			_ = neovimRemove(filepath.Join(destDir, lang+ext))
+		}
+	}
+	return nil
+}
+

--- a/internal/lib/providers/pypi_provider_test.go
+++ b/internal/lib/providers/pypi_provider_test.go
@@ -17,13 +17,24 @@ import (
 // helper to set ZANA_HOME to a temp dir
 func withTempZanaHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("ZANA_HOME", dir)
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("ZANA_HOME", t.TempDir())
+	t.Setenv("ZANA_CACHE", t.TempDir())
+
+	// Most provider tests assume the toolchain is available and stub shell outs.
+	// In CI/dev environments where e.g. cargo isn't installed, make availability checks
+	// deterministic by default (individual tests can override as needed).
+	oldCargoHas := cargoHasCommand
+	cargoHasCommand = func(string, []string, []string) bool { return true }
+	t.Cleanup(func() { cargoHasCommand = oldCargoHas })
+
 	// Ensure dirs initialized
 	_ = files.GetAppDataPath()
 	_ = files.GetAppBinPath()
 	_ = files.GetAppPackagesPath()
-	return dir
+	_ = files.GetCachePath()
+	return homeDir
 }
 
 func writeRegistry(t *testing.T, items []registry_parser.RegistryItem) {

--- a/internal/lib/providers/treesitter.go
+++ b/internal/lib/providers/treesitter.go
@@ -1,0 +1,103 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/mistweaverco/zana-client/internal/lib/files"
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/shell_out"
+)
+
+func IsTreeSitterCategory(categories []string) bool {
+	for _, c := range categories {
+		if strings.EqualFold(strings.TrimSpace(c), "Tree-sitter-parser") {
+			return true
+		}
+	}
+	return false
+}
+
+func SharedLibExt() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return ".dylib"
+	case "windows":
+		return ".dll"
+	default:
+		return ".so"
+	}
+}
+
+// injectable for tests
+var (
+	treeSitterHasCommand = shell_out.HasCommand
+	treeSitterShellOut   = shell_out.ShellOut
+	osMkdirAll           = func(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+)
+
+func HasTreeSitterCLI() bool {
+	return treeSitterHasCommand("tree-sitter", []string{"--version"}, nil)
+}
+
+func SafeArtifactPackageID(sourceID string) string {
+	// sourceID is like "github:tree-sitter/tree-sitter-typescript"
+	s := strings.TrimSpace(sourceID)
+	s = strings.ReplaceAll(s, ":", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	s = strings.ReplaceAll(s, "\\", "_")
+	return s
+}
+
+func TreeSitterArtifactPath(sourceID, version, language string) string {
+	base := filepath.Join(files.GetAppDataSharePath(), "artifacts", "treesitter", SafeArtifactPackageID(sourceID), version)
+	return filepath.Join(base, language+SharedLibExt())
+}
+
+// buildTreeSitterParsersToCache builds tree-sitter parser shared libraries from
+// upstream source into Zana's artifact cache and returns the list of languages
+// that were built.
+func BuildTreeSitterParsersToCache(
+	repoPath string,
+	sourceID string,
+	version string,
+	build []registry_parser.RegistryItemTreeSitterBuild,
+) ([]string, error) {
+	if len(build) == 0 {
+		return nil, nil
+	}
+	if strings.TrimSpace(version) == "" {
+		version = "unknown"
+	}
+	if !HasTreeSitterCLI() {
+		return nil, fmt.Errorf("tree-sitter CLI not found in PATH (required to build parsers from source)")
+	}
+
+	var built []string
+	for _, b := range build {
+		lang := strings.TrimSpace(b.Language)
+		grammarDir := strings.TrimSpace(b.GrammarDir)
+		if lang == "" || grammarDir == "" {
+			continue
+		}
+
+		outPath := TreeSitterArtifactPath(sourceID, version, lang)
+		if err := osMkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return nil, fmt.Errorf("create artifact dir: %w", err)
+		}
+
+		fullGrammarDir := filepath.Join(repoPath, filepath.FromSlash(grammarDir))
+		code, err := treeSitterShellOut("tree-sitter", []string{"build", "-o", outPath, fullGrammarDir}, "", nil)
+		if err != nil || code != 0 {
+			return nil, fmt.Errorf("tree-sitter build failed for %s in %s", lang, grammarDir)
+		}
+
+		built = append(built, lang)
+	}
+
+	return built, nil
+}
+

--- a/internal/lib/providers/treesitter_test.go
+++ b/internal/lib/providers/treesitter_test.go
@@ -1,0 +1,88 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+)
+
+func TestSafeArtifactPackageID(t *testing.T) {
+	got := SafeArtifactPackageID("github:tree-sitter/tree-sitter-typescript")
+	if strings.ContainsAny(got, ":/\\") {
+		t.Fatalf("expected sanitized id, got %q", got)
+	}
+	if got == "" {
+		t.Fatalf("expected non-empty")
+	}
+}
+
+func TestBuildTreeSitterParsersToCache_UsesShellOut(t *testing.T) {
+	// Arrange
+	oldHas := treeSitterHasCommand
+	oldShell := treeSitterShellOut
+	oldMkdir := osMkdirAll
+	t.Cleanup(func() {
+		treeSitterHasCommand = oldHas
+		treeSitterShellOut = oldShell
+		osMkdirAll = oldMkdir
+	})
+
+	treeSitterHasCommand = func(cmd string, args []string, env []string) bool { return true }
+
+	var gotArgs []string
+	treeSitterShellOut = func(command string, args []string, dir string, env []string) (int, error) {
+		if command != "tree-sitter" {
+			t.Fatalf("expected tree-sitter, got %q", command)
+		}
+		gotArgs = append([]string{}, args...)
+		return 0, nil
+	}
+
+	var mkdirPath string
+	osMkdirAll = func(path string, perm os.FileMode) error {
+		// This function is os.FileMode in prod; we accept any here to keep the stub simple.
+		mkdirPath = path
+		return nil
+	}
+
+	build := []registry_parser.RegistryItemTreeSitterBuild{
+		{Language: "typescript", GrammarDir: "typescript"},
+	}
+
+	// Act
+	langs, err := BuildTreeSitterParsersToCache("/tmp/repo", "github:tree-sitter/tree-sitter-typescript", "v0.0.1", build)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assert
+	if len(langs) != 1 || langs[0] != "typescript" {
+		t.Fatalf("unexpected languages: %#v", langs)
+	}
+	if len(gotArgs) < 4 || gotArgs[0] != "build" || gotArgs[1] != "-o" {
+		t.Fatalf("unexpected args: %#v", gotArgs)
+	}
+	if gotArgs[3] != filepath.Join("/tmp/repo", "typescript") {
+		t.Fatalf("unexpected grammar dir arg: %q", gotArgs[3])
+	}
+	if mkdirPath == "" {
+		t.Fatalf("expected mkdir to be called")
+	}
+}
+
+func TestBuildTreeSitterParsersToCache_FailsWithoutCLI(t *testing.T) {
+	oldHas := treeSitterHasCommand
+	t.Cleanup(func() { treeSitterHasCommand = oldHas })
+	treeSitterHasCommand = func(cmd string, args []string, env []string) bool { return false }
+
+	_, err := BuildTreeSitterParsersToCache("/tmp/repo", "github:x/y", "v1", []registry_parser.RegistryItemTreeSitterBuild{
+		{Language: "x", GrammarDir: "x"},
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+

--- a/internal/lib/registry_parser/root.go
+++ b/internal/lib/registry_parser/root.go
@@ -162,6 +162,15 @@ type RegistryItemSource struct {
 	Download RegistryItemSourceDownloadList `json:"download,omitempty"`
 }
 
+type RegistryItemTreeSitterBuild struct {
+	Language  string `json:"language"`
+	GrammarDir string `json:"grammar_dir"`
+}
+
+type RegistryItemTreeSitter struct {
+	Build []RegistryItemTreeSitterBuild `json:"build,omitempty"`
+}
+
 type RegistryItem struct {
 	Name              string             `json:"name"`
 	Version           string             `json:"version"`
@@ -174,6 +183,7 @@ type RegistryItem struct {
 	Aliases           []string           `json:"aliases,omitempty"`
 	Source            RegistryItemSource `json:"source"`
 	Bin               map[string]string  `json:"bin"`
+	TreeSitter        *RegistryItemTreeSitter `json:"treesitter,omitempty"`
 }
 
 type RegistryRoot []RegistryItem

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -5,6 +5,17 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "paths": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cacheDir": {
+          "type": "string",
+          "description": "Cache directory (used when ZANA_CACHE env var is not set). Supports absolute paths, ~, or paths relative to $HOME.",
+          "minLength": 1
+        }
+      }
+    },
     "registry": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
As of now, zana supports download and compilation via tree-sitter cli like this:

```sh
zana add github:tree-sitter/tree-sitter-typescript
```

This downloads the tree-sitter-typescript repository, compiles the parser and places the compiled parser in the zana cache directory.

Neovim users can now integrate the downloaded parser directly via the `--integrate` flag, which will place the compiled parser in the appropriate location (usually
`~/.local/share/nvim/site/parser/`).

```sh
zana add --integrate neovim github:tree-sitter/tree-sitter-typescript
```

You still need to activate them in your Neovim configuration, but this makes the process of acquiring

```lua
local installed_parsers = {
  "tsx",
  "typescript",
}

vim.api.nvim_create_autocmd("FileType", {
  callback = function(args)
    if not vim.list_contains(installed_parsers, args.match) then
      return
    end
    vim.treesitter.start(args.buf)
  end,
})
```