### PR TITLE
feat(sync): verbose output for current progress + lock file extras

### DIFF
--- a/cmd/zana/install.go
+++ b/cmd/zana/install.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/huh/spinner"
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
 	"github.com/mistweaverco/zana-client/internal/lib/providers"
 	"github.com/spf13/cobra"
 )
@@ -230,9 +231,10 @@ Examples:
 
 					if success {
 						successCount++
+						_ = local_packages_parser.MergePackageIntegrations(internalID, installIntegrations)
 						fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
 						for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
-							fmt.Printf("  %s\n", line)
+							fmt.Printf("  %s@%s: %s\n", internalID, resolvedVersion, line)
 						}
 					} else {
 						failureCount++
@@ -282,9 +284,10 @@ Examples:
 
 			if success {
 				successCount++
+				_ = local_packages_parser.MergePackageIntegrations(internalID, installIntegrations)
 				fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
 				for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
-					fmt.Printf("  %s\n", line)
+					fmt.Printf("  %s@%s: %s\n", internalID, resolvedVersion, line)
 				}
 			} else {
 				failureCount++

--- a/cmd/zana/sync.go
+++ b/cmd/zana/sync.go
@@ -2,8 +2,11 @@ package zana
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/charmbracelet/huh/spinner"
 	"github.com/mistweaverco/zana-client/internal/lib/files"
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
 	"github.com/mistweaverco/zana-client/internal/lib/providers"
 	"github.com/spf13/cobra"
 )
@@ -63,8 +66,97 @@ are installed with their exact versions as specified in the lock file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !ShouldUseJSONOutput() && !ShouldUsePlainOutput() {
 			fmt.Println("Syncing packages from zana-lock.json...")
+
+			lock := local_packages_parser.GetData(false)
+			if len(lock.Packages) == 0 {
+				fmt.Println("  (no packages in lockfile)")
+				fmt.Printf("%s Packages sync completed\n", IconCheck())
+				return
+			}
+
+			type pkgResult struct {
+				id                string
+				version           string
+				ok                bool
+				integrations      []string
+				integrationReport []string
+			}
+
+			results := make([]pkgResult, 0, len(lock.Packages))
+			successCount := 0
+			failureCount := 0
+
+			for _, pkg := range lock.Packages {
+				id := strings.TrimSpace(pkg.SourceID)
+				ver := strings.TrimSpace(pkg.Version)
+				if id == "" || ver == "" {
+					continue
+				}
+
+				var ints []string
+				if pkg.Extras != nil {
+					ints = pkg.Extras.Integrations
+				}
+				providers.SetRequestedIntegrations(ints)
+
+				title := fmt.Sprintf("Syncing %s@%s", id, ver)
+				if len(ints) > 0 {
+					title = fmt.Sprintf("Syncing %s@%s (integrations: %v)", id, ver, ints)
+				}
+
+				ok := false
+				action := func() {
+					ok = providers.Install(id, ver)
+				}
+
+				_ = spinner.New().Title(title).Action(action).Run()
+
+				res := pkgResult{
+					id:           id,
+					version:      ver,
+					ok:           ok,
+					integrations: ints,
+				}
+				res.integrationReport = providers.ConsumeIntegrationReport(id, ver)
+				results = append(results, res)
+
+				if ok {
+					successCount++
+					fmt.Printf("%s Synced %s@%s\n", IconCheck(), id, ver)
+					for _, line := range res.integrationReport {
+						fmt.Printf("  %s@%s: %s\n", id, ver, line)
+					}
+				} else {
+					failureCount++
+					fmt.Printf("%s Failed to sync %s@%s\n", IconClose(), id, ver)
+				}
+			}
+
+			// Final overview.
+			fmt.Printf("\nSync Summary:\n")
+			fmt.Printf("  Successfully synced: %d\n", successCount)
+			if failureCount > 0 {
+				fmt.Printf("  Failed to sync: %d\n", failureCount)
+			}
+			fmt.Printf("%s Packages sync completed\n", IconCheck())
+			return
 		}
-		syncPackagesFn()
+
+		// Plain/JSON output keeps the old all-at-once behavior for scripting.
+		if err := syncPackagesFn(); err != nil {
+			if ShouldUseJSONOutput() {
+				result := map[string]interface{}{
+					"success": false,
+					"error":   err.Error(),
+				}
+				PrintJSON(result)
+			} else {
+				fmt.Printf("%s Failed to sync packages: %v\n", IconClose(), err)
+			}
+			osExit(1)
+			return
+		}
+
 		if ShouldUseJSONOutput() {
 			result := map[string]interface{}{
 				"success": true,
@@ -89,5 +181,5 @@ func downloadAndUnzipRegistryForced() error {
 // indirections for testability
 var (
 	syncRegistryFn = downloadAndUnzipRegistryForced
-	syncPackagesFn = providers.SyncAll
+	syncPackagesFn = providers.SyncAllFromLock
 )

--- a/internal/boot/root.go
+++ b/internal/boot/root.go
@@ -97,7 +97,7 @@ func (m model) syncLocalPackages() tea.Cmd {
 
 func (m model) performSyncLocalPackages() tea.Cmd {
 	return func() tea.Msg {
-		providers.SyncAll()
+		_ = providers.SyncAllFromLock()
 		return syncLocalPackagesFinishedMsg{}
 	}
 }

--- a/internal/lib/local_packages_parser/local_packages_parser_test.go
+++ b/internal/lib/local_packages_parser/local_packages_parser_test.go
@@ -168,7 +168,10 @@ func TestLocalPackagesParserWithMock(t *testing.T) {
 		var saved LocalPackageRoot
 		_ = json.Unmarshal(written, &saved)
 		// IDs are normalized to new format, so pkg:npm/keep becomes npm:keep
-		expectedNormalized := LocalPackageRoot{Packages: []LocalPackageItem{{SourceID: "npm:keep", Version: "1.0.0"}}}
+		expectedNormalized := LocalPackageRoot{
+			Packages: []LocalPackageItem{{SourceID: "npm:keep", Version: "1.0.0"}},
+			Schema:   lockSchemaURL,
+		}
 		assert.Equal(t, expectedNormalized, saved)
 	})
 
@@ -470,6 +473,37 @@ func TestLocalPackagesParserWithMock(t *testing.T) {
 
 		assert.False(t, result)
 	})
+
+	t.Run("merge package integrations adds extras on item", func(t *testing.T) {
+		// Start with one package in the file.
+		existingData := LocalPackageRoot{
+			Packages: []LocalPackageItem{
+				{SourceID: "pkg:github/owner/repo", Version: "v1.0.0"},
+			},
+		}
+		jsonData, _ := json.Marshal(existingData)
+
+		var written []byte
+		mockFileManager := &MockFileManager{
+			GetAppLocalPackagesFilePathFunc: func() string { return "/mock/path/local-packages.json" },
+			FileExistsFunc:                  func(path string) bool { return true },
+			ReadFileFunc:                    func(path string) ([]byte, error) { return jsonData, nil },
+			WriteFileFunc:                   func(path string, data []byte, perm uint32) error { written = data; return nil },
+		}
+
+		parser := NewWithFileManager(mockFileManager)
+		err := parser.MergePackageIntegrations("github:owner/repo", []string{"Neovim", "neovim", "  "})
+		assert.NoError(t, err)
+
+		var saved LocalPackageRoot
+		_ = json.Unmarshal(written, &saved)
+		assert.Len(t, saved.Packages, 1)
+		assert.Equal(t, lockSchemaURL, saved.Schema)
+		assert.Equal(t, "github:owner/repo", saved.Packages[0].SourceID) // normalized
+		if assert.NotNil(t, saved.Packages[0].Extras) {
+			assert.Equal(t, []string{"neovim"}, saved.Packages[0].Extras.Integrations)
+		}
+	})
 }
 
 func TestMockFileManager(t *testing.T) {
@@ -565,6 +599,7 @@ func TestLegacyFunctions(t *testing.T) {
 		var saved LocalPackageRoot
 		_ = json.Unmarshal(mem, &saved)
 		assert.Len(t, saved.Packages, 1)
+		assert.Equal(t, lockSchemaURL, saved.Schema)
 		// AddLocalPackage normalizes IDs to new format
 		assert.Equal(t, "npm:legacy", saved.Packages[0].SourceID)
 		assert.Equal(t, "1.0.0", saved.Packages[0].Version)

--- a/internal/lib/local_packages_parser/root.go
+++ b/internal/lib/local_packages_parser/root.go
@@ -9,13 +9,21 @@ import (
 // marshalIndent is a package-level variable to allow injection during tests
 var marshalIndent = json.MarshalIndent
 
+const lockSchemaURL = "https://getzana.net/zana-lock.schema.json"
+
 type LocalPackageItem struct {
-	SourceID string `json:"sourceId"`
-	Version  string `json:"version"`
+	SourceID string         `json:"sourceId"`
+	Version  string         `json:"version"`
+	Extras   *PackageExtras `json:"extras,omitempty"`
+}
+
+type PackageExtras struct {
+	Integrations []string `json:"integrations,omitempty"`
 }
 
 type LocalPackageRoot struct {
 	Packages []LocalPackageItem `json:"packages"`
+	Schema   string             `json:"$schema,omitempty"`
 }
 
 // LocalPackagesParser implements LocalPackagesManager
@@ -82,6 +90,65 @@ func (lpp *LocalPackagesParser) GetData(force bool) LocalPackageRoot {
 	return localPackageRoot
 }
 
+func normalizeIntegrations(integrations []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(integrations))
+	for _, i := range integrations {
+		i = strings.ToLower(strings.TrimSpace(i))
+		if i == "" {
+			continue
+		}
+		if _, ok := seen[i]; ok {
+			continue
+		}
+		seen[i] = struct{}{}
+		out = append(out, i)
+	}
+	return out
+}
+
+func (lpp *LocalPackagesParser) MergePackageIntegrations(sourceID string, integrations []string) error {
+	integrations = normalizeIntegrations(integrations)
+	if len(integrations) == 0 {
+		return nil
+	}
+
+	sourceID = normalizePackageID(sourceID)
+	if strings.TrimSpace(sourceID) == "" {
+		return nil
+	}
+
+	root := lpp.GetData(false)
+	for i := range root.Packages {
+		if root.Packages[i].SourceID != sourceID {
+			continue
+		}
+		if root.Packages[i].Extras == nil {
+			root.Packages[i].Extras = &PackageExtras{}
+		}
+		root.Packages[i].Extras.Integrations = normalizeIntegrations(
+			append(root.Packages[i].Extras.Integrations, integrations...),
+		)
+		goto write
+	}
+	// Package not found in lockfile (shouldn't happen if caller updated it first).
+	return nil
+
+write:
+	root.Schema = lockSchemaURL
+	localPackagesFile := lpp.fileManager.GetAppLocalPackagesFilePath()
+	jsonData, err := marshalIndent(root, "", "  ")
+	if err != nil {
+		fmt.Println("Error marshaling JSON:", err)
+		return err
+	}
+	if err := lpp.fileManager.WriteFile(localPackagesFile, jsonData, 0644); err != nil {
+		fmt.Println("Error writing to file:", err)
+		return err
+	}
+	return nil
+}
+
 // GetDataForProvider returns the local packages data
 // for a specific provider. Supports both legacy (pkg:provider/pkg) and new (provider:pkg) formats.
 func (lpp *LocalPackagesParser) GetDataForProvider(provider string) LocalPackageRoot {
@@ -126,6 +193,7 @@ func (lpp *LocalPackagesParser) AddLocalPackage(sourceId string, version string)
 		})
 	}
 
+	localPackageRoot.Schema = lockSchemaURL
 	localPackagesFile := lpp.fileManager.GetAppLocalPackagesFilePath()
 	jsonData, err := marshalIndent(localPackageRoot, "", "  ")
 	if err != nil {
@@ -151,6 +219,7 @@ func (lpp *LocalPackagesParser) RemoveLocalPackage(sourceId string) error {
 		}
 	}
 
+	localPackageRoot.Schema = lockSchemaURL
 	localPackagesFile := lpp.fileManager.GetAppLocalPackagesFilePath()
 	jsonData, err := marshalIndent(localPackageRoot, "", "  ")
 	if err != nil {
@@ -211,6 +280,10 @@ func AddLocalPackage(sourceId string, version string) error {
 
 func RemoveLocalPackage(sourceId string) error {
 	return globalParser.RemoveLocalPackage(sourceId)
+}
+
+func MergePackageIntegrations(sourceId string, integrations []string) error {
+	return globalParser.MergePackageIntegrations(sourceId, integrations)
 }
 
 func GetBySourceId(sourceId string) LocalPackageItem {

--- a/internal/lib/providers/providers_test.go
+++ b/internal/lib/providers/providers_test.go
@@ -304,7 +304,7 @@ func TestUpdateWithMockFactory(t *testing.T) {
 	}
 }
 
-func TestSyncAllWithMockFactory(t *testing.T) {
+func TestSyncAllFromLockWithMockFactory(t *testing.T) {
 	// Create mock providers
 	mockNPM := &MockPackageManager{}
 	mockPyPI := &MockPackageManager{}
@@ -323,9 +323,9 @@ func TestSyncAllWithMockFactory(t *testing.T) {
 	SetProviderFactory(mockFactory)
 	defer ResetProviderFactory()
 
-	// Test that SyncAll doesn't panic
+	// Test that SyncAllFromLock doesn't panic
 	assert.NotPanics(t, func() {
-		SyncAll()
+		_ = SyncAllFromLock()
 	})
 }
 

--- a/internal/lib/providers/root.go
+++ b/internal/lib/providers/root.go
@@ -202,7 +202,7 @@ func CheckIfUpdateIsAvailable(localVersion string, remoteVersion string) (bool, 
 	return false, ""
 }
 
-func SyncAll() {
+func syncAllProviders() {
 	npmProvider := getNPMProvider()
 	if npm, ok := npmProvider.(*NPMProvider); ok {
 		npm.Sync()

--- a/internal/lib/providers/root_test.go
+++ b/internal/lib/providers/root_test.go
@@ -29,6 +29,6 @@ func TestSyncAllInvokesProviderSyncs(t *testing.T) {
 	// Ensure base packages dir exists to avoid mkdir races in different providers
 	_ = os.MkdirAll(files.GetAppPackagesPath(), 0755)
 
-	// Call SyncAll; with empty desired sets, each provider's Sync should no-op/return quickly
-	SyncAll()
+	// Call SyncAllFromLock; with empty desired sets, each provider's Sync should no-op/return quickly
+	_ = SyncAllFromLock()
 }

--- a/internal/lib/providers/sync_from_lock.go
+++ b/internal/lib/providers/sync_from_lock.go
@@ -1,0 +1,73 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+)
+
+func languagesFromTreeSitterBuild(build []registry_parser.RegistryItemTreeSitterBuild) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(build))
+	for _, b := range build {
+		lang := strings.TrimSpace(b.Language)
+		if lang == "" {
+			continue
+		}
+		if _, ok := seen[lang]; ok {
+			continue
+		}
+		seen[lang] = struct{}{}
+		out = append(out, lang)
+	}
+	return out
+}
+
+// SyncAllFromLock syncs packages and replays lockfile-configured integrations.
+func SyncAllFromLock() error {
+	lock := local_packages_parser.GetData(false)
+
+	// Keep existing behavior for ensuring packages exist.
+	// Integrations are configured per-package and replayed below.
+	SetRequestedIntegrations(nil)
+	syncAllProviders()
+
+	// Re-apply integrations even when packages are already installed.
+	registry := registry_parser.NewDefaultRegistryParser()
+	var firstErr error
+
+	for _, pkg := range lock.Packages {
+		sourceID := strings.TrimSpace(pkg.SourceID)
+		version := strings.TrimSpace(pkg.Version)
+		if sourceID == "" || version == "" {
+			continue
+		}
+
+		var integrations []string
+		if pkg.Extras != nil {
+			integrations = pkg.Extras.Integrations
+		}
+		SetRequestedIntegrations(integrations)
+
+		item := registry.GetBySourceId(sourceID)
+		if item.Source.ID == "" {
+			// Unknown to registry; nothing to integrate.
+			continue
+		}
+		if !IsTreeSitterCategory(item.Categories) {
+			continue
+		}
+		if item.TreeSitter == nil || len(item.TreeSitter.Build) == 0 {
+			continue
+		}
+
+		langs := languagesFromTreeSitterBuild(item.TreeSitter.Build)
+		if err := installNeovimParsersFromCache(item.Source.ID, version, langs); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("apply integrations for %s@%s: %w", sourceID, version, err)
+		}
+	}
+
+	return firstErr
+}

--- a/schemas/lock.schema.json
+++ b/schemas/lock.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://getzana.net/zana-lock.schema.json",
+  "title": "Zana zana-lock.json schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["packages"],
+  "properties": {
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sourceId", "version"],
+        "properties": {
+          "sourceId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Normalized package ID, e.g. \"github:user/repo\" or \"npm:eslint\"."
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Exact version/tag that was installed."
+          },
+          "extras": {
+            "type": "object",
+            "description": "Optional extension point for per-package metadata.",
+            "additionalProperties": true,
+            "properties": {
+              "integrations": {
+                "type": "array",
+                "description": "Integration backends to replay for this specific package (e.g. [\"neovim\"]).",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "enum": ["neovim"]
+                },
+                "uniqueItems": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
- Added verbose output to the sync command to show the current progress of syncing packages.
- Added extras field with integrations, so we can replay integrations as well