### PR TITLE
feat(treesitter): don't prompt for external queries once ref is recorded

### DIFF
--- a/internal/lib/providers/external_treesitter_queries.go
+++ b/internal/lib/providers/external_treesitter_queries.go
@@ -79,6 +79,35 @@ func externalQueryLockPinFromLocalLock(sourceID, version, lang string) (repoURL,
 	return "", "", false
 }
 
+// externalQueryLockPinForConfirmFilter is the lock lookup used when deciding whether to prompt for
+// external query clones; tests may replace it.
+var externalQueryLockPinForConfirmFilter = externalQueryLockPinFromLocalLock
+
+func externalQueryLockCoversNeed(sourceID, version string, n externalQueryNeed) bool {
+	lockRepo, lockRef, ok := externalQueryLockPinForConfirmFilter(sourceID, version, n.Lang)
+	if !ok || strings.TrimSpace(lockRef) == "" {
+		return false
+	}
+	return externalQueryRepoURLsEqual(lockRepo, n.URL)
+}
+
+// externalQueryNeedsStillRequiringConfirm returns only those external query needs for which the
+// lockfile does not already record an acceptable pin (same grammar version, repo URL, non-empty ref).
+// Sync and reinstall can then skip re-prompting for those languages.
+func externalQueryNeedsStillRequiringConfirm(sourceID, version string, needs []externalQueryNeed) []externalQueryNeed {
+	if len(needs) == 0 {
+		return nil
+	}
+	var out []externalQueryNeed
+	for _, n := range needs {
+		if externalQueryLockCoversNeed(sourceID, version, n) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
 // cloneExternalQueriesRepo clones repoURL into destDir, optionally checking out a tag/branch/commit.
 // When lockRef is set and lockRepoURL matches repoURL, lockRef is used instead of registry semver/ref.
 // Returns the resolved full commit SHA of HEAD.
@@ -190,6 +219,13 @@ func ConfigureExternalTreeSitterQueriesFromCLI(flagExplicit bool, flagValue stri
 type externalQueryNeed struct {
 	Lang string
 	URL  string
+}
+
+// ExternalQueryPreflightChoice records phased-install preflight consent for optional external query
+// git clones. When non-nil, the cache step skips batch confirmation. AllowUnpinned applies only to
+// languages not already covered by a matching lockfile pin (same grammar version, repo URL, ref).
+type ExternalQueryPreflightChoice struct {
+	AllowUnpinned bool
 }
 
 // plannedTreeSitterBuildLanguages returns every non-empty language from the registry build list

--- a/internal/lib/providers/external_treesitter_queries_test.go
+++ b/internal/lib/providers/external_treesitter_queries_test.go
@@ -106,3 +106,65 @@ func TestParseExternalTreeSitterQueriesPolicy_Invalid(t *testing.T) {
 	_, err := parseExternalTreeSitterQueriesPolicy("sometimes")
 	require.Error(t, err)
 }
+
+func TestExternalQueryNeedsStillRequiringConfirm_FiltersLockPinned(t *testing.T) {
+	prev := externalQueryLockPinForConfirmFilter
+	externalQueryLockPinForConfirmFilter = func(sourceID, version, lang string) (string, string, bool) {
+		if lang == "hcl" {
+			return "https://example.com/nvim-treesitter-queries-hcl", "abc123def456", true
+		}
+		return "", "", false
+	}
+	t.Cleanup(func() { externalQueryLockPinForConfirmFilter = prev })
+
+	needs := []externalQueryNeed{
+		{Lang: "hcl", URL: "https://example.com/nvim-treesitter-queries-hcl"},
+		{Lang: "lua", URL: "https://example.com/other-queries"},
+	}
+	got := externalQueryNeedsStillRequiringConfirm("github:demo/grammar", "v1.0.0", needs)
+	require.Len(t, got, 1)
+	require.Equal(t, "lua", got[0].Lang)
+}
+
+func TestExternalQueryLockCoversNeed_URLMismatchStillRequiresConfirm(t *testing.T) {
+	prev := externalQueryLockPinForConfirmFilter
+	externalQueryLockPinForConfirmFilter = func(_, _, lang string) (string, string, bool) {
+		if lang == "hcl" {
+			return "https://example.com/different-repo", "abc123", true
+		}
+		return "", "", false
+	}
+	t.Cleanup(func() { externalQueryLockPinForConfirmFilter = prev })
+
+	n := externalQueryNeed{Lang: "hcl", URL: "https://example.com/nvim-treesitter-queries-hcl"}
+	require.False(t, externalQueryLockCoversNeed("github:demo/grammar", "v1.0.0", n))
+}
+
+func TestBatchConfirmExternalTreeSitterQueries_SkippedWhenNeedsEmptyAfterLockFilter(t *testing.T) {
+	t.Cleanup(func() { _ = SetExternalTreeSitterQueriesPolicy("ask") })
+	require.NoError(t, SetExternalTreeSitterQueriesPolicy("ask"))
+
+	prev := externalTreeSitterQueriesConfirmHook
+	externalTreeSitterQueriesConfirmHook = func(_, _ string) (bool, error) {
+		t.Fatal("confirm hook should not run when every need is lock-pinned")
+		return false, nil
+	}
+	t.Cleanup(func() { externalTreeSitterQueriesConfirmHook = prev })
+
+	prevPin := externalQueryLockPinForConfirmFilter
+	externalQueryLockPinForConfirmFilter = func(_, _, lang string) (string, string, bool) {
+		if lang == "hcl" {
+			return "https://example.com/q", "deadbeef", true
+		}
+		return "", "", false
+	}
+	t.Cleanup(func() { externalQueryLockPinForConfirmFilter = prevPin })
+
+	needs := []externalQueryNeed{{Lang: "hcl", URL: "https://example.com/q"}}
+	confirm := externalQueryNeedsStillRequiringConfirm("github:demo/pkg", "v1", needs)
+	require.Empty(t, confirm)
+
+	ok, err := batchConfirmExternalTreeSitterQueries("github:demo/pkg", confirm)
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/internal/lib/providers/github_treesitter_phased_install.go
+++ b/internal/lib/providers/github_treesitter_phased_install.go
@@ -29,15 +29,15 @@ func GitHubTreeSitterUsesPhasedInteractiveInstall(sourceID string, registryItem 
 }
 
 type githubTreeSitterDeferredState struct {
-	p                 *GitHubProvider
-	sourceID          string
-	repo              string
-	repoPath          string
-	resolvedVersion   string
-	registryItem      registry_parser.RegistryItem
-	externalOverride  *bool // nil: cache step runs its own confirm; non-nil: use this (preflight already asked)
-	builtLangs        []string
-	externalQueryPins []local_packages_parser.TreeSitterExternalQueryPin
+	p                      *GitHubProvider
+	sourceID               string
+	repo                   string
+	repoPath               string
+	resolvedVersion        string
+	registryItem           registry_parser.RegistryItem
+	externalQueryPreflight *ExternalQueryPreflightChoice // nil: cache step runs lock-aware confirm; non-nil: preflight already asked
+	builtLangs             []string
+	externalQueryPins      []local_packages_parser.TreeSitterExternalQueryPin
 }
 
 var githubTreeSitterDeferred *githubTreeSitterDeferredState
@@ -100,24 +100,28 @@ func GitHubTreeSitterPreflightInteractive(sourceID, resolvedVersion string) erro
 
 	planned := plannedTreeSitterBuildLanguages(reg.TreeSitter.Build)
 	needs := collectExternalTreeSitterQueryNeeds(repoPath, reg.TreeSitter.Build, planned)
-	var ext *bool
-	if len(needs) > 0 {
-		allow, err := batchConfirmExternalTreeSitterQueries(sourceID, needs)
+	needsConfirm := externalQueryNeedsStillRequiringConfirm(sourceID, ver, needs)
+	var pre *ExternalQueryPreflightChoice
+	if len(needsConfirm) > 0 {
+		allow, err := batchConfirmExternalTreeSitterQueries(sourceID, needsConfirm)
 		if err != nil {
 			clearGitHubTreeSitterDeferred()
 			return err
 		}
-		ext = &allow
+		pre = &ExternalQueryPreflightChoice{AllowUnpinned: allow}
+	} else if len(needs) > 0 {
+		// All external-query languages are already pinned in the lockfile at this version.
+		pre = &ExternalQueryPreflightChoice{AllowUnpinned: false}
 	}
 
 	githubTreeSitterDeferred = &githubTreeSitterDeferredState{
-		p:                p,
-		sourceID:         sourceID,
-		repo:             repo,
-		repoPath:         repoPath,
-		resolvedVersion:  ver,
-		registryItem:     reg,
-		externalOverride: ext,
+		p:                      p,
+		sourceID:               sourceID,
+		repo:                   repo,
+		repoPath:               repoPath,
+		resolvedVersion:        ver,
+		registryItem:           reg,
+		externalQueryPreflight: pre,
 	}
 	return nil
 }
@@ -155,7 +159,7 @@ func GitHubTreeSitterPhaseCacheNeovimQueries(sourceID, resolvedVersion string) b
 		d.resolvedVersion,
 		d.registryItem.TreeSitter.Build,
 		d.builtLangs,
-		d.externalOverride,
+		d.externalQueryPreflight,
 	)
 	if err != nil {
 		Logger.Error(fmt.Sprintf("GitHub Install: Error caching Neovim tree-sitter queries: %v", err))

--- a/internal/lib/providers/neovim_treesitter.go
+++ b/internal/lib/providers/neovim_treesitter.go
@@ -179,7 +179,7 @@ func copyNeovimTreeSitterQueriesDir(src, dst string, inherits []string) error {
 func cacheNeovimTreeSitterQueriesAfterBuild(
 	repoPath, fullGrammarDir, sourceID, version string,
 	build registry_parser.RegistryItemTreeSitterBuild,
-	externalDownloadsAllowed bool,
+	allowExternalQueryClone func(string) bool,
 ) (*local_packages_parser.TreeSitterExternalQueryPin, error) {
 	lang := strings.TrimSpace(build.Language)
 	if lang == "" {
@@ -194,7 +194,7 @@ func cacheNeovimTreeSitterQueriesAfterBuild(
 	}
 
 	repoURL := ""
-	if build.ExternalQueries != nil && externalDownloadsAllowed {
+	if build.ExternalQueries != nil && allowExternalQueryClone(lang) {
 		repoURL = strings.TrimSpace(build.ExternalQueries.RepoURL)
 	}
 	if repoURL != "" {
@@ -252,7 +252,7 @@ func cacheNeovimTreeSitterQueriesForBuiltLangs(
 	repoPath, sourceID, version string,
 	build []registry_parser.RegistryItemTreeSitterBuild,
 	builtLangs []string,
-	externalDownloadsOverride *bool,
+	externalPreflight *ExternalQueryPreflightChoice,
 ) ([]local_packages_parser.TreeSitterExternalQueryPin, error) {
 	var pins []local_packages_parser.TreeSitterExternalQueryPin
 	want := map[string]struct{}{}
@@ -262,19 +262,48 @@ func cacheNeovimTreeSitterQueriesForBuiltLangs(
 			want[l] = struct{}{}
 		}
 	}
-	externalDownloadsAllowed := true
-	if integrationEnabled("neovim") {
-		if externalDownloadsOverride != nil {
-			externalDownloadsAllowed = *externalDownloadsOverride
-		} else {
-			needs := collectExternalTreeSitterQueryNeeds(repoPath, build, builtLangs)
-			if len(needs) > 0 {
-				var err error
-				externalDownloadsAllowed, err = batchConfirmExternalTreeSitterQueries(sourceID, needs)
-				if err != nil {
-					return nil, err
-				}
+	var allowExternalQueryClone func(string) bool
+	if !integrationEnabled("neovim") {
+		allowExternalQueryClone = func(string) bool { return false }
+	} else if externalPreflight != nil {
+		needs := collectExternalTreeSitterQueryNeeds(repoPath, build, builtLangs)
+		allowUnpinned := externalPreflight.AllowUnpinned
+		pinned := make(map[string]struct{}, len(needs))
+		for _, n := range needs {
+			if externalQueryLockCoversNeed(sourceID, version, n) {
+				pinned[strings.ToLower(strings.TrimSpace(n.Lang))] = struct{}{}
 			}
+		}
+		allowExternalQueryClone = func(lang string) bool {
+			lk := strings.ToLower(strings.TrimSpace(lang))
+			if _, ok := pinned[lk]; ok {
+				return true
+			}
+			return allowUnpinned
+		}
+	} else {
+		needs := collectExternalTreeSitterQueryNeeds(repoPath, build, builtLangs)
+		needsConfirm := externalQueryNeedsStillRequiringConfirm(sourceID, version, needs)
+		allowUnpinned := true
+		var err error
+		if len(needsConfirm) > 0 {
+			allowUnpinned, err = batchConfirmExternalTreeSitterQueries(sourceID, needsConfirm)
+			if err != nil {
+				return nil, err
+			}
+		}
+		pinned := make(map[string]struct{}, len(needs))
+		for _, n := range needs {
+			if externalQueryLockCoversNeed(sourceID, version, n) {
+				pinned[strings.ToLower(strings.TrimSpace(n.Lang))] = struct{}{}
+			}
+		}
+		allowExternalQueryClone = func(lang string) bool {
+			lk := strings.ToLower(strings.TrimSpace(lang))
+			if _, ok := pinned[lk]; ok {
+				return true
+			}
+			return allowUnpinned
 		}
 	}
 	for _, b := range build {
@@ -287,7 +316,7 @@ func cacheNeovimTreeSitterQueriesForBuiltLangs(
 			continue
 		}
 		fullGrammarDir := filepath.Join(repoPath, filepath.FromSlash(grammarDir))
-		pin, err := cacheNeovimTreeSitterQueriesAfterBuild(repoPath, fullGrammarDir, sourceID, version, b, externalDownloadsAllowed)
+		pin, err := cacheNeovimTreeSitterQueriesAfterBuild(repoPath, fullGrammarDir, sourceID, version, b, allowExternalQueryClone)
 		if err != nil {
 			return nil, err
 		}
@@ -646,8 +675,9 @@ func ensureNeovimTreeSitterInheritDependencies(registryItem registry_parser.Regi
 // buildTreeSitterOpts configures buildAndMaybeIntegrateTreeSitter for phased GitHub installs.
 type buildTreeSitterOpts struct {
 	SkipInheritDependencies bool
-	// ExternalDownloads, when non-nil, skips the external-query batch confirm and uses this value.
-	ExternalDownloads *bool
+	// ExternalQueryPreflight, when non-nil, skips the external-query batch confirm in the cache step
+	// and applies AllowUnpinned only to languages without a matching lock pin.
+	ExternalQueryPreflight *ExternalQueryPreflightChoice
 }
 
 func buildAndMaybeIntegrateTreeSitter(repoPath string, registryItem registry_parser.RegistryItem, version string, opts *buildTreeSitterOpts) ([]local_packages_parser.TreeSitterExternalQueryPin, error) {
@@ -668,11 +698,11 @@ func buildAndMaybeIntegrateTreeSitter(repoPath string, registryItem registry_par
 	if err != nil {
 		return nil, err
 	}
-	var ext *bool
+	var pre *ExternalQueryPreflightChoice
 	if opts != nil {
-		ext = opts.ExternalDownloads
+		pre = opts.ExternalQueryPreflight
 	}
-	pins, err := cacheNeovimTreeSitterQueriesForBuiltLangs(repoPath, registryItem.Source.ID, version, registryItem.TreeSitter.Build, langs, ext)
+	pins, err := cacheNeovimTreeSitterQueriesForBuiltLangs(repoPath, registryItem.Source.ID, version, registryItem.TreeSitter.Build, langs, pre)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`zana sync packages` won't prompt for external queries anymore, once it recorded the stable git commit ref in the lockfile.