### PR TITLE
feat(packages): add dependency graph resolution to all packages

### DIFF
--- a/cmd/zana/info.go
+++ b/cmd/zana/info.go
@@ -16,6 +16,9 @@ var infoCmd = &cobra.Command{
 	Short:   "Show detailed information about packages",
 	Long: `Show detailed information about one or more packages from the registry.
 
+For Tree-sitter-parser packages, also shows grammar languages, supported integrations,
+optional external query repositories, and registry requires (requires.all / requires.one).
+
 Examples:
   zana info npm:eslint
   zana info pypi:black
@@ -247,6 +250,14 @@ func displayPackageInfoRich(item registry_parser.RegistryItem, sourceID string) 
 		markdown.WriteString("\n")
 	}
 
+	extra := collectPackageExtraDetails(item)
+	if extra.Requires != nil {
+		appendRequiresMarkdown(&markdown, extra.Requires)
+	}
+	if extra.TreeSitter != nil {
+		appendTreeSitterMarkdown(&markdown, extra.TreeSitter)
+	}
+
 	// Render markdown with glamour
 	rendered, err := glamour.Render(markdown.String(), "dark")
 	if err != nil {
@@ -327,6 +338,18 @@ func displayPackageInfoPlain(item registry_parser.RegistryItem, sourceID string)
 			fmt.Printf("  %s: %s\n", binName, binPath)
 		}
 	}
+
+	extra := collectPackageExtraDetails(item)
+	if extra.Requires != nil {
+		var b strings.Builder
+		appendRequiresPlain(&b, extra.Requires)
+		fmt.Print(b.String())
+	}
+	if extra.TreeSitter != nil {
+		var b strings.Builder
+		appendTreeSitterPlain(&b, extra.TreeSitter)
+		fmt.Print(b.String())
+	}
 }
 
 // buildPackageInfoJSON builds a JSON representation of package info
@@ -395,6 +418,8 @@ func buildPackageInfoJSON(item registry_parser.RegistryItem, sourceID string) ma
 	if len(item.Bin) > 0 {
 		result["binaries"] = item.Bin
 	}
+
+	mergeExtraDetailsJSON(result, collectPackageExtraDetails(item))
 
 	return result
 }

--- a/cmd/zana/install.go
+++ b/cmd/zana/install.go
@@ -360,16 +360,16 @@ Examples:
 				if successCount > 0 {
 					fmt.Printf(" (%d you requested", successCount)
 					if depSuccess == 1 {
-						fmt.Printf(", 1 tree-sitter dependency")
+						fmt.Printf(", 1 dependency")
 					} else {
-						fmt.Printf(", %d tree-sitter dependencies", depSuccess)
+						fmt.Printf(", %d dependencies", depSuccess)
 					}
 					fmt.Printf(")\n")
 				} else {
 					if depSuccess == 1 {
-						fmt.Printf(" (1 tree-sitter dependency)\n")
+						fmt.Printf(" (1 dependency)\n")
 					} else {
-						fmt.Printf(" (%d tree-sitter dependencies)\n", depSuccess)
+						fmt.Printf(" (%d dependencies)\n", depSuccess)
 					}
 				}
 			} else {

--- a/cmd/zana/package_info_details.go
+++ b/cmd/zana/package_info_details.go
@@ -1,0 +1,384 @@
+package zana
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/providers"
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+)
+
+type packageRequiresDetails struct {
+	All          []string
+	One          []string
+	OneSatisfied []string
+	AllInstalled []string
+	AllMissing   []string
+	OneMissing   bool
+}
+
+type packageExternalQueryDetails struct {
+	RepoURL string
+	Ref     string
+	Semver  bool
+}
+
+type packageTreeSitterBuildDetails struct {
+	Language        string
+	GrammarDir      string
+	QueriesOnly     bool
+	Integrations    []string
+	Inherits        []string
+	ExternalQueries []packageExternalQueryDetails
+}
+
+type packageTreeSitterDetails struct {
+	Languages    []string
+	Integrations []string
+	Build        []packageTreeSitterBuildDetails
+}
+
+type packageExtraDetails struct {
+	Requires   *packageRequiresDetails
+	TreeSitter *packageTreeSitterDetails
+}
+
+func isTreeSitterParserPackage(item registry_parser.RegistryItem) bool {
+	return providers.IsTreeSitterCategory(item.Categories) && item.TreeSitter != nil && len(item.TreeSitter.Build) > 0
+}
+
+func collectPackageExtraDetails(item registry_parser.RegistryItem) packageExtraDetails {
+	out := packageExtraDetails{}
+	if item.Requires != nil && !item.Requires.IsEmpty() {
+		out.Requires = collectRequiresDetails(item.Requires)
+	}
+	if isTreeSitterParserPackage(item) {
+		out.TreeSitter = collectTreeSitterDetails(item)
+	}
+	return out
+}
+
+func collectRequiresDetails(req *registry_parser.RegistryItemRequires) *packageRequiresDetails {
+	d := &packageRequiresDetails{
+		All: append([]string(nil), req.All...),
+		One: append([]string(nil), req.One...),
+	}
+	for _, ref := range req.All {
+		id := normalizeInfoPackageRef(ref)
+		if packageIsInstalled(id) {
+			d.AllInstalled = append(d.AllInstalled, id)
+		} else {
+			d.AllMissing = append(d.AllMissing, id)
+		}
+	}
+	for _, ref := range req.One {
+		id := normalizeInfoPackageRef(ref)
+		if packageIsInstalled(id) {
+			d.OneSatisfied = append(d.OneSatisfied, id)
+		}
+	}
+	d.OneMissing = len(req.One) > 0 && len(d.OneSatisfied) == 0
+	sort.Strings(d.All)
+	sort.Strings(d.One)
+	sort.Strings(d.AllInstalled)
+	sort.Strings(d.AllMissing)
+	sort.Strings(d.OneSatisfied)
+	return d
+}
+
+func collectTreeSitterDetails(item registry_parser.RegistryItem) *packageTreeSitterDetails {
+	langSeen := map[string]struct{}{}
+	intSeen := map[string]struct{}{}
+	var langs []string
+	var integrations []string
+	var builds []packageTreeSitterBuildDetails
+
+	for _, b := range item.TreeSitter.Build {
+		lang := strings.TrimSpace(b.Language)
+		if lang != "" {
+			if _, ok := langSeen[lang]; !ok {
+				langSeen[lang] = struct{}{}
+				langs = append(langs, lang)
+			}
+		}
+		row := packageTreeSitterBuildDetails{
+			Language:    lang,
+			GrammarDir:  strings.TrimSpace(b.GrammarDir),
+			QueriesOnly: b.QueriesOnly,
+			Inherits:    append([]string(nil), b.Inherits...),
+		}
+		for _, in := range b.Integrations {
+			in = strings.TrimSpace(in)
+			if in == "" {
+				continue
+			}
+			row.Integrations = append(row.Integrations, in)
+			if _, ok := intSeen[in]; !ok {
+				intSeen[in] = struct{}{}
+				integrations = append(integrations, in)
+			}
+		}
+		sort.Strings(row.Integrations)
+		sort.Strings(row.Inherits)
+		for _, q := range b.ExternalQueries {
+			if strings.TrimSpace(q.RepoURL) == "" {
+				continue
+			}
+			row.ExternalQueries = append(row.ExternalQueries, packageExternalQueryDetails{
+				RepoURL: strings.TrimSpace(q.RepoURL),
+				Ref:     strings.TrimSpace(q.Ref),
+				Semver:  q.Semver,
+			})
+		}
+		builds = append(builds, row)
+	}
+
+	sort.Strings(langs)
+	sort.Strings(integrations)
+	return &packageTreeSitterDetails{
+		Languages:    langs,
+		Integrations: integrations,
+		Build:        builds,
+	}
+}
+
+func normalizeInfoPackageRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if strings.HasPrefix(ref, "pkg:") {
+		legacy := strings.TrimPrefix(ref, "pkg:")
+		parts := strings.SplitN(legacy, "/", 2)
+		if len(parts) == 2 {
+			return parts[0] + ":" + parts[1]
+		}
+	}
+	if idx := strings.LastIndex(ref, "@"); idx > 0 {
+		base := ref[:idx]
+		if strings.Contains(base, ":") {
+			return base
+		}
+	}
+	return ref
+}
+
+var packageIsInstalled = local_packages_parser.IsPackageInstalled
+
+func formatExternalQueryLine(q packageExternalQueryDetails) string {
+	var tags []string
+	if q.Semver {
+		tags = append(tags, "semver")
+	}
+	if q.Ref != "" {
+		tags = append(tags, "ref="+q.Ref)
+	}
+	if len(tags) == 0 {
+		return q.RepoURL
+	}
+	return fmt.Sprintf("%s (%s)", q.RepoURL, strings.Join(tags, ", "))
+}
+
+func appendRequiresPlain(b *strings.Builder, req *packageRequiresDetails) {
+	b.WriteString("Requires:\n")
+	if len(req.All) > 0 {
+		b.WriteString("  all (every package must be installed):\n")
+		for _, id := range req.All {
+			mark := requireInstallMark(id, req)
+			b.WriteString(fmt.Sprintf("    %s %s\n", mark, id))
+		}
+	}
+	if len(req.One) > 0 {
+		b.WriteString("  one (at least one must be installed):\n")
+		for _, id := range req.One {
+			mark := requireInstallMark(id, req)
+			b.WriteString(fmt.Sprintf("    %s %s\n", mark, id))
+		}
+	}
+}
+
+func requireInstallMark(id string, req *packageRequiresDetails) string {
+	for _, s := range req.AllInstalled {
+		if s == id {
+			return "[installed]"
+		}
+	}
+	for _, s := range req.OneSatisfied {
+		if s == id {
+			return "[installed]"
+		}
+	}
+	return "[not installed]"
+}
+
+func appendRequiresMarkdown(b *strings.Builder, req *packageRequiresDetails) {
+	b.WriteString("## Requires\n\n")
+	if len(req.All) > 0 {
+		b.WriteString("**All of** (every package must be installed):\n\n")
+		for _, id := range req.All {
+			b.WriteString(fmt.Sprintf("- %s `%s`\n", requireInstallMarkMarkdown(id, req), id))
+		}
+		b.WriteString("\n")
+	}
+	if len(req.One) > 0 {
+		b.WriteString("**One of** (at least one must be installed):\n\n")
+		for _, id := range req.One {
+			b.WriteString(fmt.Sprintf("- %s `%s`\n", requireInstallMarkMarkdown(id, req), id))
+		}
+		b.WriteString("\n")
+	}
+}
+
+func requireInstallMarkMarkdown(id string, req *packageRequiresDetails) string {
+	for _, s := range req.AllInstalled {
+		if s == id {
+			return "✅"
+		}
+	}
+	for _, s := range req.OneSatisfied {
+		if s == id {
+			return "✅"
+		}
+	}
+	return "⬜"
+}
+
+func appendTreeSitterPlain(b *strings.Builder, ts *packageTreeSitterDetails) {
+	b.WriteString("Tree-sitter:\n")
+	if len(ts.Languages) > 0 {
+		b.WriteString(fmt.Sprintf("  Languages: %s\n", strings.Join(ts.Languages, ", ")))
+	}
+	if len(ts.Integrations) > 0 {
+		b.WriteString(fmt.Sprintf("  Integrations: %s\n", strings.Join(ts.Integrations, ", ")))
+	}
+	for _, row := range ts.Build {
+		label := row.Language
+		if label == "" {
+			label = "(unknown)"
+		}
+		if row.QueriesOnly {
+			label += " (queries only)"
+		}
+		b.WriteString(fmt.Sprintf("  Build %s:\n", label))
+		if row.GrammarDir != "" && !row.QueriesOnly {
+			b.WriteString(fmt.Sprintf("    Grammar directory: %s\n", row.GrammarDir))
+		}
+		if len(row.Integrations) > 0 {
+			b.WriteString(fmt.Sprintf("    Integrations: %s\n", strings.Join(row.Integrations, ", ")))
+		}
+		if len(row.Inherits) > 0 {
+			b.WriteString(fmt.Sprintf("    Inherits: %s\n", strings.Join(row.Inherits, ", ")))
+		}
+		if len(row.ExternalQueries) > 0 {
+			b.WriteString("    External queries (optional):\n")
+			for _, q := range row.ExternalQueries {
+				b.WriteString(fmt.Sprintf("      - %s\n", formatExternalQueryLine(q)))
+			}
+		}
+	}
+}
+
+func appendTreeSitterMarkdown(b *strings.Builder, ts *packageTreeSitterDetails) {
+	b.WriteString("## Tree-sitter\n\n")
+	if len(ts.Languages) > 0 {
+		b.WriteString(fmt.Sprintf("**Languages installed:** %s\n\n", strings.Join(ts.Languages, ", ")))
+	}
+	if len(ts.Integrations) > 0 {
+		b.WriteString(fmt.Sprintf("**Supported integrations:** %s\n\n", strings.Join(ts.Integrations, ", ")))
+	}
+	for _, row := range ts.Build {
+		title := row.Language
+		if title == "" {
+			title = "build"
+		}
+		if row.QueriesOnly {
+			title += " (queries only)"
+		}
+		b.WriteString(fmt.Sprintf("### %s\n\n", title))
+		if row.GrammarDir != "" && !row.QueriesOnly {
+			b.WriteString(fmt.Sprintf("- **Grammar directory:** `%s`\n", row.GrammarDir))
+		}
+		if len(row.Integrations) > 0 {
+			b.WriteString(fmt.Sprintf("- **Integrations:** %s\n", strings.Join(row.Integrations, ", ")))
+		}
+		if len(row.Inherits) > 0 {
+			b.WriteString(fmt.Sprintf("- **Inherits:** %s\n", strings.Join(row.Inherits, ", ")))
+		}
+		if len(row.ExternalQueries) > 0 {
+			b.WriteString("- **External queries (optional):**\n")
+			for _, q := range row.ExternalQueries {
+				b.WriteString(fmt.Sprintf("  - %s\n", formatExternalQueryLine(q)))
+			}
+		}
+		b.WriteString("\n")
+	}
+}
+
+func requiresDetailsJSON(req *packageRequiresDetails) map[string]interface{} {
+	out := map[string]interface{}{}
+	if len(req.All) > 0 {
+		out["all"] = req.All
+		out["all_installed"] = req.AllInstalled
+		out["all_missing"] = req.AllMissing
+	}
+	if len(req.One) > 0 {
+		out["one"] = req.One
+		out["one_satisfied"] = req.OneSatisfied
+		out["one_missing"] = req.OneMissing
+	}
+	return out
+}
+
+func treeSitterDetailsJSON(ts *packageTreeSitterDetails) map[string]interface{} {
+	builds := make([]map[string]interface{}, 0, len(ts.Build))
+	for _, row := range ts.Build {
+		entry := map[string]interface{}{
+			"language": row.Language,
+		}
+		if row.GrammarDir != "" {
+			entry["grammar_dir"] = row.GrammarDir
+		}
+		if row.QueriesOnly {
+			entry["queries_only"] = true
+		}
+		if len(row.Integrations) > 0 {
+			entry["integrations"] = row.Integrations
+		}
+		if len(row.Inherits) > 0 {
+			entry["inherits"] = row.Inherits
+		}
+		if len(row.ExternalQueries) > 0 {
+			queries := make([]map[string]interface{}, 0, len(row.ExternalQueries))
+			for _, q := range row.ExternalQueries {
+				qm := map[string]interface{}{"repo_url": q.RepoURL}
+				if q.Ref != "" {
+					qm["ref"] = q.Ref
+				}
+				if q.Semver {
+					qm["semver"] = true
+				}
+				queries = append(queries, qm)
+			}
+			entry["external_queries"] = queries
+		}
+		builds = append(builds, entry)
+	}
+	out := map[string]interface{}{
+		"build": builds,
+	}
+	if len(ts.Languages) > 0 {
+		out["languages"] = ts.Languages
+	}
+	if len(ts.Integrations) > 0 {
+		out["integrations"] = ts.Integrations
+	}
+	return out
+}
+
+func mergeExtraDetailsJSON(result map[string]interface{}, extra packageExtraDetails) {
+	if extra.Requires != nil {
+		result["requires"] = requiresDetailsJSON(extra.Requires)
+	}
+	if extra.TreeSitter != nil {
+		result["treesitter"] = treeSitterDetailsJSON(extra.TreeSitter)
+	}
+}

--- a/cmd/zana/package_info_details_test.go
+++ b/cmd/zana/package_info_details_test.go
@@ -1,0 +1,89 @@
+package zana
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+)
+
+func TestCollectPackageExtraDetails_TreeSitterAndRequires(t *testing.T) {
+	prev := packageIsInstalled
+	defer func() { packageIsInstalled = prev }()
+	packageIsInstalled = func(id string) bool {
+		return id == "npm:tree-sitter-cli"
+	}
+
+	item := registry_parser.RegistryItem{
+		Name:       "tree-sitter-rust",
+		Categories: []string{"Tree-sitter-parser"},
+		Languages:  []string{"rust"},
+		Requires: &registry_parser.RegistryItemRequires{
+			One: []string{"npm:tree-sitter-cli", "github:tree-sitter/tree-sitter"},
+		},
+		TreeSitter: &registry_parser.RegistryItemTreeSitter{
+			Build: []registry_parser.RegistryItemTreeSitterBuild{
+				{
+					Language:     "rust",
+					GrammarDir:   ".",
+					Integrations: []string{"neovim"},
+					ExternalQueries: registry_parser.TreeSitterExternalQueriesList{
+						{RepoURL: "https://github.com/neovim-treesitter/nvim-treesitter-queries-rust", Semver: true},
+					},
+				},
+			},
+		},
+	}
+
+	extra := collectPackageExtraDetails(item)
+	if extra.Requires == nil || len(extra.Requires.One) != 2 {
+		t.Fatalf("requires: %+v", extra.Requires)
+	}
+	if len(extra.Requires.OneSatisfied) != 1 || extra.Requires.OneSatisfied[0] != "npm:tree-sitter-cli" {
+		t.Fatalf("one satisfied: %v", extra.Requires.OneSatisfied)
+	}
+	if extra.TreeSitter == nil || len(extra.TreeSitter.Languages) != 1 {
+		t.Fatalf("treesitter: %+v", extra.TreeSitter)
+	}
+	if len(extra.TreeSitter.Build[0].ExternalQueries) != 1 {
+		t.Fatal("expected external queries")
+	}
+}
+
+func TestAppendTreeSitterPlain(t *testing.T) {
+	var b strings.Builder
+	appendTreeSitterPlain(&b, &packageTreeSitterDetails{
+		Languages:    []string{"ruby"},
+		Integrations: []string{"neovim"},
+		Build: []packageTreeSitterBuildDetails{
+			{
+				Language:     "ruby",
+				GrammarDir:   ".",
+				Integrations: []string{"neovim"},
+				ExternalQueries: []packageExternalQueryDetails{
+					{RepoURL: "https://example.com/queries", Semver: true},
+				},
+			},
+		},
+	})
+	out := b.String()
+	if !strings.Contains(out, "Languages: ruby") {
+		t.Fatalf("missing languages: %q", out)
+	}
+	if !strings.Contains(out, "External queries") {
+		t.Fatalf("missing external queries: %q", out)
+	}
+}
+
+func TestRequiresDetailsJSON(t *testing.T) {
+	j := requiresDetailsJSON(&packageRequiresDetails{
+		All:          []string{"npm:a"},
+		One:          []string{"npm:b", "github:c/d"},
+		OneSatisfied: []string{"npm:b"},
+		AllMissing:   []string{"npm:a"},
+		OneMissing:   false,
+	})
+	if j["all"] == nil || j["one"] == nil {
+		t.Fatalf("json: %v", j)
+	}
+}

--- a/cmd/zana/spinner_install.go
+++ b/cmd/zana/spinner_install.go
@@ -19,6 +19,11 @@ func runZanaInstallWithTreeSitterSpinnerPhases(
 	registryItem registry_parser.RegistryItem,
 	installFn func() bool,
 ) (success bool, err error) {
+	// Top-level registry requires (requires.all / requires.one) must run before any
+	// tree-sitter phased or provider install path (e.g. tree-sitter-cli for GitHub grammars).
+	if e := providers.PreflightPackageRequires(registryItem); e != nil {
+		return false, e
+	}
 	if providers.GitHubTreeSitterUsesPhasedInteractiveInstall(sourceID, registryItem) {
 		if e := providers.GitHubTreeSitterPreflightInteractive(sourceID, resolvedVersion); e != nil {
 			return false, e

--- a/cmd/zana/sync.go
+++ b/cmd/zana/sync.go
@@ -84,6 +84,14 @@ are installed with their exact versions as specified in the lock file.`,
 				return
 			}
 
+			if err := providers.EnsureLockfilePackageRequires(false); err != nil {
+				fmt.Printf("%s %v\n", IconClose(), err)
+				osExit(1)
+				return
+			}
+			providers.ResetTreeSitterDependencyInstallSuccessCount()
+			lock = local_packages_parser.GetData(false)
+
 			type pkgResult struct {
 				id                string
 				version           string

--- a/internal/lib/providers/package_requires.go
+++ b/internal/lib/providers/package_requires.go
@@ -1,0 +1,397 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/mattn/go-isatty"
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/spinnerutil"
+)
+
+// packageRequiresIsInstalled is injectable for tests.
+var packageRequiresIsInstalled = local_packages_parser.IsPackageInstalled
+
+// packageRequiresLockData is injectable for tests.
+var packageRequiresLockData = local_packages_parser.GetData
+
+// packageRequiresNewRegistry is injectable for tests.
+var packageRequiresNewRegistry = registry_parser.NewDefaultRegistryParser
+
+// packageRequiresInstallFn is injectable for tests.
+var packageRequiresInstallFn = func(sourceID, version string) bool {
+	return Install(sourceID, version)
+}
+
+// packageRequiresResolveVersion is injectable for tests.
+var packageRequiresResolveVersion = ResolveVersion
+
+// packageRequiresPrompt is swapped in tests to avoid interactive huh.
+var packageRequiresPrompt = defaultPackageRequiresPrompt
+
+type packageRequiresPromptAction string
+
+const (
+	packageRequiresAbort   packageRequiresPromptAction = "abort"
+	packageRequiresInstall packageRequiresPromptAction = "install"
+)
+
+func defaultPackageRequiresPrompt(title, description string) (packageRequiresPromptAction, error) {
+	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stderr.Fd()) {
+		return packageRequiresAbort, fmt.Errorf("%s\n%s", title, description)
+	}
+	var choice packageRequiresPromptAction = packageRequiresInstall
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[packageRequiresPromptAction]().
+				Title(title).
+				Description(description).
+				Options(
+					huh.NewOption("Install missing dependencies", packageRequiresInstall),
+					huh.NewOption("Abort", packageRequiresAbort),
+				).
+				Value(&choice),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return packageRequiresAbort, err
+	}
+	return choice, nil
+}
+
+// packageRequiresOnePicker selects one package when a requires.one group is unsatisfied.
+var packageRequiresOnePicker = defaultPackageRequiresOnePicker
+
+func defaultPackageRequiresOnePicker(title string, options []string) (string, error) {
+	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stderr.Fd()) {
+		return "", fmt.Errorf("%s: choose one of: %s", title, strings.Join(options, ", "))
+	}
+	var choice string
+	opts := make([]huh.Option[string], 0, len(options))
+	for _, o := range options {
+		opts = append(opts, huh.NewOption(o, o))
+	}
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(title).
+				Options(opts...).
+				Value(&choice),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return "", err
+	}
+	return choice, nil
+}
+
+// PreflightPackageRequires installs registry-declared dependencies for the package
+// before the main install spinner runs (interactive: prompts when deps are missing).
+func PreflightPackageRequires(registryItem registry_parser.RegistryItem) error {
+	return ensurePackageRequires(registryItem, false)
+}
+
+// EnsureLockfilePackageRequires installs registry-declared dependencies for every
+// package in zana-lock.json. When autoInstall is true, missing deps are installed
+// without prompts (used by non-interactive sync).
+func EnsureLockfilePackageRequires(autoInstall bool) error {
+	lock := packageRequiresLockData(false)
+	reg := packageRequiresNewRegistry()
+	seen := map[string]struct{}{}
+	var combined []string
+	for _, pkg := range lock.Packages {
+		id := normalizePackageID(strings.TrimSpace(pkg.SourceID))
+		if id == "" {
+			continue
+		}
+		order, err := requiresInstallOrder(id, reg, autoInstall)
+		if err != nil {
+			return err
+		}
+		for _, depID := range order {
+			if _, ok := seen[depID]; ok {
+				continue
+			}
+			seen[depID] = struct{}{}
+			combined = append(combined, depID)
+		}
+	}
+	if len(combined) == 0 {
+		return nil
+	}
+	var missing []string
+	for _, id := range combined {
+		if !packageRequiresIsInstalled(id) {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	if !autoInstall {
+		var hint strings.Builder
+		for _, id := range missing {
+			fmt.Fprintf(&hint, "\n• zana install %s", id)
+		}
+		title := fmt.Sprintf("Missing required package(s) for lockfile: %s", strings.Join(missing, ", "))
+		desc := "These dependencies are declared in the registry and must be installed first." + hint.String()
+		action, err := packageRequiresPrompt(title, desc)
+		if err != nil {
+			return err
+		}
+		if action != packageRequiresInstall {
+			return fmt.Errorf("aborted: install required package(s) first%s", hint.String())
+		}
+	}
+	return installRequiredPackages(combined, reg)
+}
+
+func ensurePackageRequires(registryItem registry_parser.RegistryItem, autoInstall bool) error {
+	if registryItem.Source.ID == "" || registryItem.Requires == nil || registryItem.Requires.IsEmpty() {
+		return nil
+	}
+	reg := packageRequiresNewRegistry()
+	order, err := requiresInstallOrder(registryItem.Source.ID, reg, autoInstall)
+	if err != nil {
+		return err
+	}
+	if len(order) == 0 {
+		return nil
+	}
+	var missing []string
+	for _, id := range order {
+		if !packageRequiresIsInstalled(id) {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	if !autoInstall {
+		sort.Strings(missing)
+		var hint strings.Builder
+		for _, id := range missing {
+			fmt.Fprintf(&hint, "\n• zana install %s", id)
+		}
+		title := fmt.Sprintf("Missing required package(s) for %s: %s", registryItem.Name, strings.Join(missing, ", "))
+		desc := "These dependencies are declared in the registry and must be installed first." + hint.String()
+		action, err := packageRequiresPrompt(title, desc)
+		if err != nil {
+			return err
+		}
+		if action != packageRequiresInstall {
+			return fmt.Errorf("aborted: install required package(s) first%s", hint.String())
+		}
+	}
+	return installRequiredPackages(order, reg)
+}
+
+func installRequiredPackages(order []string, reg *registry_parser.RegistryParser) error {
+	for _, id := range order {
+		if packageRequiresIsInstalled(id) {
+			continue
+		}
+		ver, err := packageRequiresResolveVersion(id, "")
+		if err != nil {
+			return fmt.Errorf("resolve version for required package %s: %w", id, err)
+		}
+		dispVer := strings.TrimSpace(ver)
+		if dispVer == "" {
+			dispVer = "latest"
+		}
+		title := fmt.Sprintf("Installing required dependency %s@%s...", id, dispVer)
+		var installFailed bool
+		action := func() {
+			if !packageRequiresInstallFn(id, ver) {
+				installFailed = true
+			}
+		}
+		if err := spinnerutil.RunWithTTYOrPlain(title, nil, action); err != nil {
+			return err
+		}
+		if installFailed {
+			return fmt.Errorf("failed to install required package %s", id)
+		}
+		noteTreeSitterDependencyInstallSuccess()
+		if !packageRequiresIsInstalled(id) {
+			return fmt.Errorf("required package %s was not recorded in the lockfile after install", id)
+		}
+	}
+	return nil
+}
+
+// requiresInstallOrder returns transitive registry requires for sourceID in install-first order.
+func requiresInstallOrder(sourceID string, reg *registry_parser.RegistryParser, autoInstall bool) ([]string, error) {
+	resolving := map[string]bool{}
+	resolved := map[string]bool{}
+	var order []string
+	_, err := collectRequiresInstallOrder(sourceID, reg, autoInstall, resolving, resolved, &order)
+	return order, err
+}
+
+func collectRequiresInstallOrder(
+	sourceID string,
+	reg *registry_parser.RegistryParser,
+	autoInstall bool,
+	resolving map[string]bool,
+	resolved map[string]bool,
+	order *[]string,
+) (bool, error) {
+	id := normalizePackageID(sourceID)
+	if id == "" {
+		return false, nil
+	}
+	if resolving[id] {
+		return false, fmt.Errorf("cyclic package requires involving %s", id)
+	}
+	item := reg.GetBySourceId(id)
+	if item.Source.ID == "" || item.Requires == nil || item.Requires.IsEmpty() {
+		return false, nil
+	}
+	resolving[id] = true
+	defer delete(resolving, id)
+
+	deps, err := expandRegistryRequires(item.Requires, reg, autoInstall)
+	if err != nil {
+		return false, err
+	}
+	for _, depID := range deps {
+		if _, err := collectRequiresInstallOrder(depID, reg, autoInstall, resolving, resolved, order); err != nil {
+			return false, err
+		}
+		if resolved[depID] {
+			continue
+		}
+		*order = append(*order, depID)
+		resolved[depID] = true
+	}
+	return true, nil
+}
+
+func expandRegistryRequires(req *registry_parser.RegistryItemRequires, reg *registry_parser.RegistryParser, autoInstall bool) ([]string, error) {
+	var deps []string
+	seen := map[string]struct{}{}
+	add := func(id string) {
+		n := normalizePackageID(id)
+		if n == "" {
+			return
+		}
+		if _, ok := seen[n]; ok {
+			return
+		}
+		seen[n] = struct{}{}
+		deps = append(deps, n)
+	}
+	for _, ref := range req.All {
+		id, _, err := parseRequirePackageRef(ref)
+		if err != nil {
+			return nil, err
+		}
+		add(id)
+	}
+	if len(req.One) > 0 {
+		chosen, err := resolveRequiresOneChoice(req.One, autoInstall)
+		if err != nil {
+			return nil, err
+		}
+		if chosen != "" {
+			add(chosen)
+		}
+	}
+	sort.Strings(deps)
+	return deps, nil
+}
+
+func resolveRequiresOneChoice(refs []string, autoInstall bool) (string, error) {
+	if requiresOneSatisfied(refs) {
+		return "", nil
+	}
+	var options []string
+	for _, ref := range refs {
+		id, _, err := parseRequirePackageRef(ref)
+		if err != nil {
+			return "", err
+		}
+		options = append(options, normalizePackageID(id))
+	}
+	sort.Strings(options)
+	if autoInstall {
+		if len(options) == 0 {
+			return "", nil
+		}
+		return options[0], nil
+	}
+	title := "Choose one required package to install"
+	chosen, err := packageRequiresOnePicker(title, options)
+	if err != nil {
+		return "", err
+	}
+	return normalizePackageID(chosen), nil
+}
+
+func requiresOneSatisfied(refs []string) bool {
+	for _, ref := range refs {
+		id, _, err := parseRequirePackageRef(ref)
+		if err != nil {
+			continue
+		}
+		if packageRequiresIsInstalled(normalizePackageID(id)) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRequirePackageRef splits a registry requires entry into source ID and optional version.
+func parseRequirePackageRef(ref string) (sourceID string, version string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", "", fmt.Errorf("empty package requires reference")
+	}
+	if strings.HasPrefix(ref, "pkg:") {
+		base, ver := splitRequirePackageVersion(ref)
+		legacy := strings.TrimPrefix(base, "pkg:")
+		parts := strings.SplitN(legacy, "/", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("invalid legacy requires reference %q", ref)
+		}
+		return normalizePackageID(parts[0] + ":" + parts[1]), ver, nil
+	}
+	if !strings.Contains(ref, ":") {
+		return "", "", fmt.Errorf("invalid requires reference %q: expected <provider>:<package-id>[@version]", ref)
+	}
+	base, ver := splitRequirePackageVersion(ref)
+	return normalizePackageID(base), ver, nil
+}
+
+func splitRequirePackageVersion(pkgID string) (string, string) {
+	parts := strings.Split(pkgID, "@")
+	if len(parts) > 1 {
+		last := parts[len(parts)-1]
+		if requireRefVersionLooksValid(last) {
+			return strings.Join(parts[:len(parts)-1], "@"), last
+		}
+	}
+	return pkgID, ""
+}
+
+func requireRefVersionLooksValid(version string) bool {
+	if version == "" {
+		return false
+	}
+	lower := strings.ToLower(version)
+	if lower == "latest" || lower == "prerelease" {
+		return true
+	}
+	for _, c := range version {
+		if c >= '0' && c <= '9' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/lib/providers/package_requires_test.go
+++ b/internal/lib/providers/package_requires_test.go
@@ -1,0 +1,296 @@
+package providers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mistweaverco/zana-client/internal/lib/local_packages_parser"
+	"github.com/mistweaverco/zana-client/internal/lib/registry_parser"
+)
+
+func TestParseRequirePackageRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		ref      string
+		wantID   string
+		wantVer  string
+		wantFail bool
+	}{
+		{"npm:tree-sitter-cli", "npm:tree-sitter-cli", "", false},
+		{"npm:tree-sitter-cli@0.25.0", "npm:tree-sitter-cli", "0.25.0", false},
+		{"github:tree-sitter/tree-sitter@v0.25.0", "github:tree-sitter/tree-sitter", "v0.25.0", false},
+		{"npm:@scope/pkg@1.2.3", "npm:@scope/pkg", "1.2.3", false},
+		{"pkg:npm/foo@1.0.0", "npm:foo", "1.0.0", false},
+		{"", "", "", true},
+		{"invalid", "", "", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.ref, func(t *testing.T) {
+			t.Parallel()
+			id, ver, err := parseRequirePackageRef(tc.ref)
+			if tc.wantFail {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.ref)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID || ver != tc.wantVer {
+				t.Fatalf("got %q@%q want %q@%q", id, ver, tc.wantID, tc.wantVer)
+			}
+		})
+	}
+}
+
+func testRegistryParser(t *testing.T, items registry_parser.RegistryRoot) *registry_parser.RegistryParser {
+	t.Helper()
+	reg := registry_parser.NewRegistryParser(nil)
+	raw, err := json.Marshal(items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.LoadFromBytes(raw); err != nil {
+		t.Fatal(err)
+	}
+	return reg
+}
+
+func TestRequiresInstallOrder_TransitiveAndAll(t *testing.T) {
+	reg := testRegistryParser(t, registry_parser.RegistryRoot{
+		{
+			Name: "app",
+			Source: registry_parser.RegistryItemSource{
+				ID: "npm:app",
+			},
+			Requires: &registry_parser.RegistryItemRequires{
+				All: []string{"npm:lib-a"},
+			},
+		},
+		{
+			Name: "lib-a",
+			Source: registry_parser.RegistryItemSource{
+				ID: "npm:lib-a",
+			},
+			Requires: &registry_parser.RegistryItemRequires{
+				All: []string{"npm:lib-b"},
+			},
+		},
+		{
+			Name: "lib-b",
+			Source: registry_parser.RegistryItemSource{
+				ID: "npm:lib-b",
+			},
+		},
+	})
+	order, err := requiresInstallOrder("npm:app", reg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"npm:lib-b", "npm:lib-a"}
+	if len(order) != len(want) {
+		t.Fatalf("order %v want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order %v want %v", order, want)
+		}
+	}
+}
+
+func TestRequiresInstallOrder_Cycle(t *testing.T) {
+	reg := testRegistryParser(t, registry_parser.RegistryRoot{
+		{
+			Name: "a",
+			Source: registry_parser.RegistryItemSource{
+				ID: "npm:a",
+			},
+			Requires: &registry_parser.RegistryItemRequires{
+				All: []string{"npm:b"},
+			},
+		},
+		{
+			Name: "b",
+			Source: registry_parser.RegistryItemSource{
+				ID: "npm:b",
+			},
+			Requires: &registry_parser.RegistryItemRequires{
+				All: []string{"npm:a"},
+			},
+		},
+	})
+	_, err := requiresInstallOrder("npm:a", reg, false)
+	if err == nil || !strings.Contains(err.Error(), "cyclic") {
+		t.Fatalf("expected cyclic error, got %v", err)
+	}
+}
+
+func TestExpandRegistryRequires_OneSatisfiedSkips(t *testing.T) {
+	prev := packageRequiresIsInstalled
+	defer func() { packageRequiresIsInstalled = prev }()
+	packageRequiresIsInstalled = func(sourceID string) bool {
+		return sourceID == "npm:tree-sitter-cli"
+	}
+	req := &registry_parser.RegistryItemRequires{
+		One: []string{"npm:tree-sitter-cli", "github:tree-sitter/tree-sitter"},
+	}
+	deps, err := expandRegistryRequires(req, registry_parser.NewRegistryParser(nil), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("expected no deps when one is satisfied, got %v", deps)
+	}
+}
+
+func TestExpandRegistryRequires_OneAutoInstallPicksFirst(t *testing.T) {
+	prevInstalled := packageRequiresIsInstalled
+	defer func() { packageRequiresIsInstalled = prevInstalled }()
+	packageRequiresIsInstalled = func(string) bool { return false }
+	req := &registry_parser.RegistryItemRequires{
+		One: []string{"npm:tree-sitter-cli", "github:tree-sitter/tree-sitter"},
+	}
+	deps, err := expandRegistryRequires(req, registry_parser.NewRegistryParser(nil), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 1 || deps[0] != "github:tree-sitter/tree-sitter" {
+		t.Fatalf("got %v", deps)
+	}
+}
+
+func TestExpandRegistryRequires_OnePromptsWhenMissing(t *testing.T) {
+	prevInstalled := packageRequiresIsInstalled
+	prevPicker := packageRequiresOnePicker
+	defer func() {
+		packageRequiresIsInstalled = prevInstalled
+		packageRequiresOnePicker = prevPicker
+	}()
+	packageRequiresIsInstalled = func(string) bool { return false }
+	packageRequiresOnePicker = func(_ string, options []string) (string, error) {
+		return options[0], nil
+	}
+	req := &registry_parser.RegistryItemRequires{
+		One: []string{"npm:tree-sitter-cli", "github:tree-sitter/tree-sitter"},
+	}
+	deps, err := expandRegistryRequires(req, registry_parser.NewRegistryParser(nil), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 1 || deps[0] != "github:tree-sitter/tree-sitter" {
+		t.Fatalf("got %v", deps)
+	}
+}
+
+func TestPreflightPackageRequires_PromptsForRequiresOne(t *testing.T) {
+	prevInstalled := packageRequiresIsInstalled
+	prevInstall := packageRequiresInstallFn
+	prevResolve := packageRequiresResolveVersion
+	prevPicker := packageRequiresOnePicker
+	prevPrompt := packageRequiresPrompt
+	defer func() {
+		packageRequiresIsInstalled = prevInstalled
+		packageRequiresInstallFn = prevInstall
+		packageRequiresResolveVersion = prevResolve
+		packageRequiresOnePicker = prevPicker
+		packageRequiresPrompt = prevPrompt
+	}()
+	packageRequiresIsInstalled = func(string) bool { return false }
+	packageRequiresResolveVersion = func(string, string) (string, error) {
+		return "0.25.0", nil
+	}
+	var installed []string
+	packageRequiresInstallFn = func(sourceID, version string) bool {
+		installed = append(installed, sourceID)
+		return true
+	}
+	packageRequiresOnePicker = func(_ string, options []string) (string, error) {
+		return options[0], nil
+	}
+	packageRequiresPrompt = func(string, string) (packageRequiresPromptAction, error) {
+		return packageRequiresInstall, nil
+	}
+	packageRequiresIsInstalled = func(id string) bool {
+		for _, i := range installed {
+			if i == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	item := registry_parser.RegistryItem{
+		Name:       "tree-sitter-svelte",
+		Categories: []string{"Tree-sitter-parser"},
+		Source:     registry_parser.RegistryItemSource{ID: "github:tree-sitter-grammars/tree-sitter-svelte"},
+		Requires: &registry_parser.RegistryItemRequires{
+			One: []string{"npm:tree-sitter-cli", "github:tree-sitter/tree-sitter"},
+		},
+	}
+	if err := PreflightPackageRequires(item); err != nil {
+		t.Fatal(err)
+	}
+	if len(installed) != 1 || installed[0] != "github:tree-sitter/tree-sitter" {
+		t.Fatalf("installed %v", installed)
+	}
+}
+
+func TestEnsureLockfilePackageRequires_AutoInstall(t *testing.T) {
+	prevInstalled := packageRequiresIsInstalled
+	prevInstall := packageRequiresInstallFn
+	prevResolve := packageRequiresResolveVersion
+	defer func() {
+		packageRequiresIsInstalled = prevInstalled
+		packageRequiresInstallFn = prevInstall
+		packageRequiresResolveVersion = prevResolve
+	}()
+	packageRequiresResolveVersion = func(string, string) (string, error) {
+		return "1.0.0", nil
+	}
+	installed := map[string]struct{}{"npm:app": {}}
+	packageRequiresIsInstalled = func(sourceID string) bool {
+		_, ok := installed[sourceID]
+		return ok
+	}
+	var installedOrder []string
+	packageRequiresInstallFn = func(sourceID, version string) bool {
+		installed[sourceID] = struct{}{}
+		installedOrder = append(installedOrder, sourceID)
+		return true
+	}
+	reg := testRegistryParser(t, registry_parser.RegistryRoot{
+		{
+			Name:   "app",
+			Source: registry_parser.RegistryItemSource{ID: "npm:app"},
+			Requires: &registry_parser.RegistryItemRequires{
+				All: []string{"npm:lib-a"},
+			},
+		},
+		{
+			Name:   "lib-a",
+			Source: registry_parser.RegistryItemSource{ID: "npm:lib-a"},
+		},
+	})
+	prevReg := packageRequiresNewRegistry
+	packageRequiresNewRegistry = func() *registry_parser.RegistryParser { return reg }
+	defer func() { packageRequiresNewRegistry = prevReg }()
+
+	lock := local_packages_parser.LocalPackageRoot{
+		Packages: []local_packages_parser.LocalPackageItem{
+			{SourceID: "npm:app", Version: "1.0.0"},
+		},
+	}
+	prevLock := packageRequiresLockData
+	packageRequiresLockData = func(bool) local_packages_parser.LocalPackageRoot { return lock }
+	defer func() { packageRequiresLockData = prevLock }()
+
+	if err := EnsureLockfilePackageRequires(true); err != nil {
+		t.Fatal(err)
+	}
+	if len(installedOrder) != 1 || installedOrder[0] != "npm:lib-a" {
+		t.Fatalf("installed %v", installedOrder)
+	}
+}

--- a/internal/lib/providers/sync_from_lock.go
+++ b/internal/lib/providers/sync_from_lock.go
@@ -27,6 +27,9 @@ func languagesFromTreeSitterBuild(build []registry_parser.RegistryItemTreeSitter
 
 // SyncAllFromLock syncs packages and replays lockfile-configured integrations.
 func SyncAllFromLock() error {
+	if err := EnsureLockfilePackageRequires(true); err != nil {
+		return err
+	}
 	lock := local_packages_parser.GetData(false)
 
 	// Keep existing behavior for ensuring packages exist.

--- a/internal/lib/registry_parser/root.go
+++ b/internal/lib/registry_parser/root.go
@@ -223,6 +223,16 @@ type RegistryItemTreeSitter struct {
 	Build []RegistryItemTreeSitterBuild `json:"build,omitempty"`
 }
 
+// RegistryItemRequires declares package dependencies that must be satisfied before install.
+type RegistryItemRequires struct {
+	All []string `json:"all,omitempty"`
+	One []string `json:"one,omitempty"`
+}
+
+func (r *RegistryItemRequires) IsEmpty() bool {
+	return r == nil || (len(r.All) == 0 && len(r.One) == 0)
+}
+
 type RegistryItem struct {
 	Name              string                  `json:"name"`
 	Version           string                  `json:"version"`
@@ -236,6 +246,7 @@ type RegistryItem struct {
 	Source            RegistryItemSource      `json:"source"`
 	Bin               map[string]string       `json:"bin"`
 	TreeSitter        *RegistryItemTreeSitter `json:"treesitter,omitempty"`
+	Requires          *RegistryItemRequires   `json:"requires,omitempty"`
 }
 
 type RegistryRoot []RegistryItem


### PR DESCRIPTION
each package can contain the optional `requires` field.

The requires field has optional `one` and `all` fields. The `one` field is an array of arrays of package names. The `all` field is an array of package names.

When a package is being installed, the requires field is used to determine which other packages need to be installed before the package can be installed.

If the package has a `one` field, at least one of the packages in each array must be installed before the package can be installed.

The user can choose which package to install from each array in the `one` field.

If the package has an `all` field, all of the packages in the array must be installed before the package can be installed.