### PR TITLE
feat(cli): add `filter`, and `[no-]always-trust` flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,17 +332,28 @@ Optional list constraints (combinable with each other and with name filters):
 - `--only-categories`: comma-separated category tokens; a package matches if
   any of its registry categories matches any token (substring match,
   case-insensitive), for example `lsp,tree-sitter-parser`.
+- `--only-always-trusted`: show only packages with `extras.always_trust` in
+  the lockfile.
+- `--filter '[.]path:value'`: repeatable AND filters over the same fields as
+  `nvpm show -o json` (see Filter DSL below).
 
 ```sh
 nvpm ls --only-outdated
 nvpm ls --only-providers pypi --only-categories lsp
 nvpm ls -A --only-providers npm --only-outdated
+nvpm ls --only-always-trusted
+nvpm ls --filter 'categories:*tree*' --filter 'provider:github'
 ```
 
 Installed list output uses three columns: **Package ID**, **Installed**, and **Available**.
 The Available column shows install candidates (tags, branches, or `semver` versions) that
 have passed local discovery, or `in X days/hours` when `--min-release-age` is still
-waiting. Use `nvpm show` for full git ref comparison, update-resolution rationale,
+waiting. This works for **all providers** (`npm`, `pypi`, `github`, etc.):
+the first time `ls` surfaces a newer registry version,
+it records local first-seen so Available can show
+`4.11.0 in 7 days`.
+
+Use `nvpm show` for full git ref comparison, update-resolution rationale,
 and tag-overwrite alerts. JSON output (`--output json`) still includes
 `discovered_versions`, `eligible_versions`, and `eligible_soon_versions`.
 
@@ -355,6 +366,7 @@ also includes:
 - **Update resolution** - active policy and why a branch was chosen over a stale tag
 - **Discovery** - remote commit date vs when you first recorded the version locally
 - **Alerts** - force-moved tags/releases
+- **Always trust** - whether `extras.always_trust` skips `min-release-age` for the package
 
 ```sh
 nvpm show github:folke/ts-comments.nvim
@@ -370,6 +382,37 @@ nvpm up github:user/repo --update-resolution branches:main,develop;release-age-g
 
 Overrides are stored in `nvpm-lock.json` under `extras.update_resolution` (see
 `schemas/lock.schema.json`).
+
+`--always-trust` / `--no-always-trust` on `add` and `up` persistently skip (or clear)
+`min-release-age` for that package via lock `extras.always_trust`. Unlike `--force`
+(one-shot for the current command), `--always-trust` is stored and applied on later
+installs/updates until cleared.
+
+```sh
+nvpm add npm:eslint --always-trust
+nvpm up npm:eslint --no-always-trust
+```
+
+#### Filter DSL
+
+`--filter` is available on `ls`, `show`, `add`, `up`, and `rm`. Repeat the flag for
+AND semantics. Each value is `[.]path:value` against the package's `show` JSON fields
+(`name`, `package_id`, `categories`, `provider`, `always_trust`, `git_refs`, `status`, …).
+
+- Leading `.` is optional
+- Paths are dot-separated; arrays match if **any** element matches the remainder
+- The first `:` separates path from value (so `package_id:github:owner/repo` works)
+- Values are case-insensitive; `*` and `?` are globs (`*` matches any characters, including `/` and `:`); without wildcards, match is exact
+- Booleans: `always_trust:true` / `false`
+- Missing path → no match
+
+```sh
+nvpm ls --filter '.categories:*tree*'
+nvpm ls --filter 'package_id:github:mistweaverco*'
+nvpm show mistweaver --filter 'package_id:*mistweaverco/*'
+nvpm up --all --filter 'provider:npm'
+nvpm rm eslint --filter 'categories:LSP'
+```
 
 #### `nvpm up`
 

--- a/cmd/nvpm/add.go
+++ b/cmd/nvpm/add.go
@@ -126,6 +126,11 @@ Examples:
 	// Enable shell completion for package IDs based on the local registry.
 	ValidArgsFunction: packageIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := validateAlwaysTrustFlags(); err != nil {
+			fmt.Printf("%s %v\n", IconClose(), err)
+			osExit(1)
+			return
+		}
 		providers.SetMinReleaseAgePolicy(providers.MinReleaseAgePolicy{
 			MinAge: cfg.Flags.MinReleaseAge,
 			Force:  installForce,
@@ -217,6 +222,9 @@ Examples:
 
 				// Process all selected packages
 				for _, selectedSourceID := range selectedSourceIDs {
+					if !packageMatchesShowFilters(selectedSourceID, getShowFilters(cmd)) {
+						continue
+					}
 					internalID := selectedSourceID
 					// selectedSourceID is already in provider:package-id format, use it directly
 					displayID := selectedSourceID
@@ -234,6 +242,7 @@ Examples:
 						failures = append(failures, displayID)
 						continue
 					}
+					applyPendingAlwaysTrust(internalID)
 
 					// Resolve version before installing to show actual version in spinner
 					resolvedVersion, err := resolveVersionFn(internalID, version)
@@ -241,6 +250,7 @@ Examples:
 						printProviderRequirementError(displayID, err)
 						failureCount++
 						failures = append(failures, displayID)
+						clearPendingAlwaysTrust(internalID)
 						continue
 					}
 
@@ -257,6 +267,7 @@ Examples:
 						fmt.Printf("%s %v\n", IconClose(), err)
 						failureCount++
 						failures = append(failures, displayID)
+						clearPendingAlwaysTrust(internalID)
 						continue
 					}
 					providers.SetRequestedIntegrations(effectiveIntegrations)
@@ -266,6 +277,7 @@ Examples:
 						fmt.Printf("%s %v\n", IconClose(), kindErr)
 						failureCount++
 						failures = append(failures, displayID)
+						clearPendingAlwaysTrust(internalID)
 						continue
 					}
 
@@ -281,6 +293,7 @@ Examples:
 						failures = append(failures, displayID)
 						fmt.Printf("%s Failed to install %s@%s: %v\n", IconClose(), displayID, resolvedVersion, err)
 						clearPendingUpdateResolution(internalID)
+						clearPendingAlwaysTrust(internalID)
 						continue
 					}
 
@@ -288,6 +301,7 @@ Examples:
 						successCount++
 						_ = local_packages_parser.MergePackageIntegrations(internalID, effectiveIntegrations)
 						persistUpdateResolutionAfterInstall(internalID)
+						persistAlwaysTrustAfterInstall(internalID)
 						fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
 						for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
 							fmt.Printf("  %s@%s: %s\n", internalID, resolvedVersion, line)
@@ -297,6 +311,7 @@ Examples:
 						failures = append(failures, displayID)
 						printInstallFailure(displayID, resolvedVersion)
 						clearPendingUpdateResolution(internalID)
+						clearPendingAlwaysTrust(internalID)
 					}
 				}
 				continue // Skip the single package processing below
@@ -323,12 +338,17 @@ Examples:
 				continue
 			}
 
+			if !packageMatchesShowFilters(internalID, getShowFilters(cmd)) {
+				continue
+			}
+
 			if err := applyPendingUpdateResolution(internalID); err != nil {
 				fmt.Printf("%s Invalid --update-resolution: %v\n", IconClose(), err)
 				failureCount++
 				failures = append(failures, displayID)
 				continue
 			}
+			applyPendingAlwaysTrust(internalID)
 
 			// Resolve version before installing to show actual version in spinner
 			resolvedVersion, err := resolveVersionFn(internalID, version)
@@ -336,6 +356,7 @@ Examples:
 				printProviderRequirementError(displayID, err)
 				failureCount++
 				failures = append(failures, displayID)
+				clearPendingAlwaysTrust(internalID)
 				continue
 			}
 
@@ -352,6 +373,7 @@ Examples:
 				fmt.Printf("%s %v\n", IconClose(), err)
 				failureCount++
 				failures = append(failures, displayID)
+				clearPendingAlwaysTrust(internalID)
 				continue
 			}
 			providers.SetRequestedIntegrations(effectiveIntegrations)
@@ -361,6 +383,7 @@ Examples:
 				fmt.Printf("%s %v\n", IconClose(), kindErr)
 				failureCount++
 				failures = append(failures, displayID)
+				clearPendingAlwaysTrust(internalID)
 				continue
 			}
 
@@ -376,6 +399,7 @@ Examples:
 				failures = append(failures, displayID)
 				fmt.Printf("%s Failed to install %s@%s: %v\n", IconClose(), displayID, resolvedVersion, err)
 				clearPendingUpdateResolution(internalID)
+				clearPendingAlwaysTrust(internalID)
 				continue
 			}
 
@@ -383,6 +407,7 @@ Examples:
 				successCount++
 				_ = local_packages_parser.MergePackageIntegrations(internalID, effectiveIntegrations)
 				persistUpdateResolutionAfterInstall(internalID)
+				persistAlwaysTrustAfterInstall(internalID)
 				fmt.Printf("%s Successfully installed %s@%s\n", IconCheck(), displayID, resolvedVersion)
 				for _, line := range providers.ConsumeIntegrationReport(internalID, resolvedVersion) {
 					fmt.Printf("  %s@%s: %s\n", internalID, resolvedVersion, line)
@@ -392,6 +417,7 @@ Examples:
 				failures = append(failures, displayID)
 				printInstallFailure(displayID, resolvedVersion)
 				clearPendingUpdateResolution(internalID)
+				clearPendingAlwaysTrust(internalID)
 			}
 		}
 
@@ -450,8 +476,11 @@ func init() {
 	addCmd.Flags().StringSliceVar(&installIntegrations, "integrate", nil, "run integration backends after install (e.g. --integrate neovim)")
 	addCmd.Flags().StringVar(&installExternalTreeSitterQueries, "external-treesitter-queries", "ask", "when Neovim integration needs optional query-only git repos from the registry: ask (default), always, never (overridden by NVPM_EXTERNAL_TREESITTER_QUERIES when this flag is left at default)")
 	addCmd.Flags().BoolVar(&installForce, "force", false, "bypass min-release-age safety checks")
+	addCmd.Flags().BoolVar(&installAlwaysTrust, "always-trust", false, "persistently skip min-release-age for this package (stored in lock extras.always_trust)")
+	addCmd.Flags().BoolVar(&installNoAlwaysTrust, "no-always-trust", false, "clear extras.always_trust for this package")
 	addCmd.Flags().StringVar(&installUpdateResolution, "update-resolution", "", "git-only: override update-resolution for this package (e.g. always, release-age-gap:30d, branches:main,develop)")
 	addCmd.Flags().StringVar(&installPluginEditor, "plugin", "", "install as an editor plugin (under plugins/ instead of packages/); supported: neovim")
+	registerShowFilterFlag(addCmd)
 }
 
 func printInstallFailure(displayID, resolvedVersion string) {

--- a/cmd/nvpm/add_test.go
+++ b/cmd/nvpm/add_test.go
@@ -21,6 +21,10 @@ func TestInstallCommand(t *testing.T) {
 	aliases := addCmd.Aliases
 	assert.Contains(t, aliases, "install")
 	assert.Len(t, aliases, 1)
+
+	assert.NotNil(t, addCmd.Flags().Lookup("always-trust"))
+	assert.NotNil(t, addCmd.Flags().Lookup("no-always-trust"))
+	assert.NotNil(t, addCmd.Flags().Lookup("filter"))
 }
 
 func TestInstallCommandArgs(t *testing.T) {

--- a/cmd/nvpm/always_trust_install.go
+++ b/cmd/nvpm/always_trust_install.go
@@ -1,0 +1,44 @@
+package nvpm
+
+import (
+	"fmt"
+
+	"github.com/mistweaverco/nvpm-client/internal/lib/local_packages_parser"
+	"github.com/mistweaverco/nvpm-client/internal/lib/providers"
+)
+
+var (
+	installAlwaysTrust   bool
+	installNoAlwaysTrust bool
+)
+
+func validateAlwaysTrustFlags() error {
+	if installAlwaysTrust && installNoAlwaysTrust {
+		return fmt.Errorf("--always-trust and --no-always-trust are mutually exclusive")
+	}
+	return nil
+}
+
+func alwaysTrustFlagChanged() bool {
+	return installAlwaysTrust || installNoAlwaysTrust
+}
+
+func applyPendingAlwaysTrust(sourceID string) {
+	if !alwaysTrustFlagChanged() {
+		return
+	}
+	providers.SetPendingAlwaysTrust(sourceID, installAlwaysTrust)
+}
+
+func persistAlwaysTrustAfterInstall(sourceID string) {
+	if !alwaysTrustFlagChanged() {
+		providers.ClearPendingAlwaysTrust(sourceID)
+		return
+	}
+	_ = local_packages_parser.MergePackageAlwaysTrust(sourceID, installAlwaysTrust)
+	providers.ClearPendingAlwaysTrust(sourceID)
+}
+
+func clearPendingAlwaysTrust(sourceID string) {
+	providers.ClearPendingAlwaysTrust(sourceID)
+}

--- a/cmd/nvpm/discovered_format_test.go
+++ b/cmd/nvpm/discovered_format_test.go
@@ -25,6 +25,8 @@ func TestFormatPreferBranchDisplay(t *testing.T) {
 	))
 	assert.Equal(t, "main (322c79d)", formatEligibleGitRef("main", "322c79dabcdef", 0))
 	assert.Equal(t, "main (322c79d) in 7 days", formatEligibleGitRef("main", "322c79dabcdef", 7*24*time.Hour))
+	assert.Equal(t, "4.11.0", formatEligibleVersion("4.11.0", 0))
+	assert.Equal(t, "4.11.0 in 7 days", formatEligibleVersion("4.11.0", 7*24*time.Hour))
 	assert.Equal(t, "7 days", formatInDays(7*24*time.Hour))
 	assert.Equal(t, "1 day", formatInDays(time.Hour))
 }

--- a/cmd/nvpm/info.go
+++ b/cmd/nvpm/info.go
@@ -119,6 +119,8 @@ Examples:
 			}
 		}
 
+		packagesToShow = filterSourceIDsByShowFilters(packagesToShow, getShowFilters(cmd))
+
 		// Display info for each package
 		if ShouldUseJSONOutput() {
 			// Collect all packages for JSON output
@@ -237,6 +239,9 @@ func displayPackageInfoRich(item registry_parser.RegistryItem, sourceID string) 
 		} else {
 			markdown.WriteString("**Status:** ✅ Installed\n\n")
 		}
+		if packageAlwaysTrustFromLock(sourceID) {
+			markdown.WriteString("**Always trust:** yes (min-release-age skipped)\n\n")
+		}
 	} else {
 		markdown.WriteString("**Status:** ⬜ Not installed\n\n")
 	}
@@ -329,6 +334,9 @@ func displayPackageInfoPlain(item registry_parser.RegistryItem, sourceID string)
 		} else {
 			fmt.Printf("Status: Installed\n")
 		}
+		if packageAlwaysTrustFromLock(sourceID) {
+			fmt.Printf("Always trust: yes (min-release-age skipped)\n")
+		}
 	} else {
 		fmt.Printf("Status: Not installed\n")
 	}
@@ -416,6 +424,9 @@ func buildPackageInfoJSON(item registry_parser.RegistryItem, sourceID string) ma
 		if installedVersion != "" {
 			result["installed_version"] = installedVersion
 		}
+		if packageAlwaysTrustFromLock(sourceID) {
+			result["always_trust"] = true
+		}
 	}
 	result["status"] = status
 
@@ -427,4 +438,18 @@ func buildPackageInfoJSON(item registry_parser.RegistryItem, sourceID string) ma
 	mergeGitDetailsJSON(result, collectPackageGitDetails(item, sourceID))
 
 	return result
+}
+
+func packageAlwaysTrustFromLock(sourceID string) bool {
+	localPackagesRoot := newLocalPackagesParserFn()
+	for _, pkg := range localPackagesRoot.Packages {
+		if pkg.SourceID == sourceID {
+			return pkg.Extras != nil && pkg.Extras.AlwaysTrust
+		}
+	}
+	return false
+}
+
+func init() {
+	registerShowFilterFlag(infoCmd)
 }

--- a/cmd/nvpm/ls.go
+++ b/cmd/nvpm/ls.go
@@ -101,15 +101,19 @@ func init() {
 	lsCmd.Flags().String("only-providers", "", "Comma-separated provider names to include, e.g. pypi,npm")
 	lsCmd.Flags().String("only-categories", "", "Comma-separated category tokens; a package matches if any of its registry categories matches any token (substring match, case-insensitive), e.g. lsp,tree-sitter-parser")
 	lsCmd.Flags().Bool("only-plugins", false, "Show only Neovim plugins (lock entries with extras.kind neovim-plugin)")
+	lsCmd.Flags().Bool("only-always-trusted", false, "Show only packages with extras.always_trust in the lock file")
+	registerShowFilterFlag(lsCmd)
 }
 
 // ListQueryOptions holds positional name filters plus optional list constraints.
 type ListQueryOptions struct {
-	NameFilters    []string
-	OnlyOutdated   bool
-	OnlyProviders  []string // lowercase provider names (validated)
-	OnlyCategories []string // trimmed tokens from --only-categories
-	OnlyPlugins    bool     // lock entries with extras.kind neovim-plugin
+	NameFilters       []string
+	OnlyOutdated      bool
+	OnlyProviders     []string // lowercase provider names (validated)
+	OnlyCategories    []string // trimmed tokens from --only-categories
+	OnlyPlugins       bool     // lock entries with extras.kind neovim-plugin
+	OnlyAlwaysTrusted bool     // lock extras.always_trust
+	ShowFilters       []string // --filter path:value (AND, match show JSON)
 }
 
 func listQueryOptionsFromFlags(cmd *cobra.Command, args []string) (ListQueryOptions, error) {
@@ -124,6 +128,8 @@ func listQueryOptionsFromFlags(cmd *cobra.Command, args []string) (ListQueryOpti
 	onlyCat, _ := cmd.Flags().GetString("only-categories")
 	opts.OnlyCategories = parseCommaSeparatedList(onlyCat)
 	opts.OnlyPlugins, _ = cmd.Flags().GetBool("only-plugins")
+	opts.OnlyAlwaysTrusted, _ = cmd.Flags().GetBool("only-always-trusted")
+	opts.ShowFilters, _ = cmd.Flags().GetStringArray("filter")
 	return opts, nil
 }
 
@@ -195,7 +201,7 @@ func registryItemMatchesCategoryFilters(categories []string, filters []string) b
 }
 
 func (o ListQueryOptions) hasAdvancedFilters() bool {
-	return o.OnlyOutdated || len(o.OnlyProviders) > 0 || len(o.OnlyCategories) > 0 || o.OnlyPlugins
+	return o.OnlyOutdated || len(o.OnlyProviders) > 0 || len(o.OnlyCategories) > 0 || o.OnlyPlugins || o.OnlyAlwaysTrusted || len(o.ShowFilters) > 0
 }
 
 func (o ListQueryOptions) constraintDescriptionPlain() string {
@@ -215,6 +221,12 @@ func (o ListQueryOptions) constraintDescriptionPlain() string {
 	if o.OnlyPlugins {
 		parts = append(parts, "neovim plugins only")
 	}
+	if o.OnlyAlwaysTrusted {
+		parts = append(parts, "always-trusted only")
+	}
+	if len(o.ShowFilters) > 0 {
+		parts = append(parts, fmt.Sprintf("filters: %s", strings.Join(o.ShowFilters, ", ")))
+	}
 	return " - " + strings.Join(parts, "; ")
 }
 
@@ -232,6 +244,20 @@ func (o ListQueryOptions) constraintDescriptionMarkdown() string {
 	if len(o.OnlyCategories) > 0 {
 		parts = append(parts, fmt.Sprintf("categories: **%s**", strings.Join(o.OnlyCategories, ", ")))
 	}
+	if o.OnlyPlugins {
+		parts = append(parts, "neovim plugins only")
+	}
+	if o.OnlyAlwaysTrusted {
+		parts = append(parts, "always-trusted only")
+	}
+	if len(o.ShowFilters) > 0 {
+		// Backticks: filter values often contain '*' which would break **bold** markdown.
+		quoted := make([]string, 0, len(o.ShowFilters))
+		for _, f := range o.ShowFilters {
+			quoted = append(quoted, "`"+f+"`")
+		}
+		parts = append(parts, fmt.Sprintf("filters: %s", strings.Join(quoted, ", ")))
+	}
 	return " - " + strings.Join(parts, "; ")
 }
 
@@ -244,6 +270,15 @@ func appendListQueryJSONFields(m map[string]any, o ListQueryOptions) {
 	}
 	if len(o.OnlyCategories) > 0 {
 		m["only_categories"] = append([]string(nil), o.OnlyCategories...)
+	}
+	if o.OnlyPlugins {
+		m["only_plugins"] = true
+	}
+	if o.OnlyAlwaysTrusted {
+		m["only_always_trusted"] = true
+	}
+	if len(o.ShowFilters) > 0 {
+		m["filters_dsl"] = append([]string(nil), o.ShowFilters...)
 	}
 }
 
@@ -410,10 +445,20 @@ func formatEligibleGitRef(ref, commit string, remaining time.Duration) string {
 	if sha != "" {
 		base = fmt.Sprintf("%s (%s)", ref, sha)
 	}
-	if remaining > 0 {
-		return fmt.Sprintf("%s in %s", base, formatInDuration(remaining))
+	return formatEligibleVersion(base, remaining)
+}
+
+// formatEligibleVersion formats Eligible / EligibleSoon for non-git versions.
+// Eligible: "4.11.0"; soon: "4.11.0 in 7 days".
+func formatEligibleVersion(version string, remaining time.Duration) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return version
 	}
-	return base
+	if remaining > 0 {
+		return fmt.Sprintf("%s in %s", version, formatInDuration(remaining))
+	}
+	return version
 }
 
 func shortGitSHA(commit string) string {
@@ -642,32 +687,77 @@ func (ls *ListService) discoveryDisplayForInstalled(sourceID, installedVersion, 
 		return out
 	}
 
-	discovered, err := providers.ListDiscoveredVersions(sourceID)
-	if err != nil || len(discovered) == 0 {
-		return discoveryDisplay{Available: avail}
-	}
-
 	now := time.Now()
 	minAge := cfg.Flags.MinReleaseAge
-
 	out := discoveryDisplay{Available: avail}
-	for _, dv := range discovered {
-		version := dv.Version
-		if providers.IsGitCommitHash(version) {
-			version = dv.Version[:7]
-		}
-		// Always show what's been recorded, even if it's not newer than installed.
-		out.Discovered = append(out.Discovered, formatDiscoveredVersion(version, dv.FirstSeen, now))
+	eligibleSeen := map[string]struct{}{}
 
-		// Eligibility is only meaningful for versions newer than what's installed.
-		if shouldRecordDiscoveredVersion(installedVersion, dv.Version) {
-			age := now.Sub(dv.FirstSeen)
-			if minAge <= 0 || age >= minAge {
-				out.Eligible = append(out.Eligible, version)
+	// Registry candidates newer than installed: lazy-record first-seen (like git) and
+	// fill Eligible / EligibleSoon so Available can show "in X days" even when discovery.json
+	// was empty (warm registry cache).
+	candidates := make([]string, 0, 2)
+	if v := strings.TrimSpace(stable); v != "" && v != "latest" {
+		candidates = append(candidates, v)
+	}
+	if v := strings.TrimSpace(prerelease); v != "" && v != "latest" && v != strings.TrimSpace(stable) {
+		candidates = append(candidates, v)
+	}
+	for _, v := range candidates {
+		if !shouldRecordDiscoveredVersion(installedVersion, v) {
+			continue
+		}
+		firstSeen, found, err := providers.GetFirstSeen(sourceID, v)
+		if err != nil || !found {
+			_ = providers.RecordDiscoveryBatch([]providers.DiscoveryPair{{
+				SourceID: sourceID,
+				Version:  v,
+			}})
+			if t, seen, getErr := providers.GetFirstSeen(sourceID, v); getErr == nil && seen {
+				firstSeen = t
 			} else {
-				out.EligibleSoon = append(out.EligibleSoon, version)
+				firstSeen = now
 			}
 		}
+		displayVersion := v
+		if providers.IsGitCommitHash(displayVersion) {
+			displayVersion = displayVersion[:7]
+		}
+		age := now.Sub(firstSeen)
+		if minAge <= 0 || age >= minAge {
+			out.Eligible = append(out.Eligible, formatEligibleVersion(displayVersion, 0))
+		} else {
+			out.EligibleSoon = append(out.EligibleSoon, formatEligibleVersion(displayVersion, minAge-age))
+		}
+		eligibleSeen[v] = struct{}{}
+	}
+
+	discovered, err := providers.ListDiscoveredVersions(sourceID)
+	if err != nil {
+		return out
+	}
+	for _, dv := range discovered {
+		version := dv.Version
+		displayVersion := version
+		if providers.IsGitCommitHash(displayVersion) {
+			displayVersion = version[:7]
+		}
+		// Always show what's been recorded, even if it's not newer than installed.
+		out.Discovered = append(out.Discovered, formatDiscoveredVersion(displayVersion, dv.FirstSeen, now))
+
+		// Eligibility for versions already in discovery but not covered by registry candidates.
+		if !shouldRecordDiscoveredVersion(installedVersion, dv.Version) {
+			continue
+		}
+		if _, ok := eligibleSeen[dv.Version]; ok {
+			continue
+		}
+		age := now.Sub(dv.FirstSeen)
+		if minAge <= 0 || age >= minAge {
+			out.Eligible = append(out.Eligible, formatEligibleVersion(displayVersion, 0))
+		} else {
+			out.EligibleSoon = append(out.EligibleSoon, formatEligibleVersion(displayVersion, minAge-age))
+		}
+		eligibleSeen[dv.Version] = struct{}{}
 	}
 	return out
 }
@@ -929,6 +1019,16 @@ func (ls *ListService) applyAdvancedFiltersToInstalled(packages []local_packages
 		return packages
 	}
 	catByID := ls.registryCategoriesBySourceID()
+	var itemsByID map[string]registry_parser.RegistryItem
+	if len(opts.ShowFilters) > 0 {
+		itemsByID = make(map[string]registry_parser.RegistryItem)
+		for _, it := range ls.registry.GetData(false) {
+			id := strings.TrimSpace(it.Source.ID)
+			if id != "" {
+				itemsByID[id] = it
+			}
+		}
+	}
 	out := make([]local_packages_parser.LocalPackageItem, 0, len(packages))
 	for _, pkg := range packages {
 		prov := getProviderFromSourceID(pkg.SourceID)
@@ -948,6 +1048,20 @@ func (ls *ListService) applyAdvancedFiltersToInstalled(packages []local_packages
 		}
 		if opts.OnlyPlugins {
 			if pkg.Extras == nil || pkg.Extras.Kind != local_packages_parser.KindNeovimPlugin {
+				continue
+			}
+		}
+		if opts.OnlyAlwaysTrusted {
+			if pkg.Extras == nil || !pkg.Extras.AlwaysTrust {
+				continue
+			}
+		}
+		if len(opts.ShowFilters) > 0 {
+			if item, ok := itemsByID[pkg.SourceID]; ok {
+				if !MatchShowJSON(buildPackageInfoJSON(item, pkg.SourceID), opts.ShowFilters) {
+					continue
+				}
+			} else if !packageMatchesShowFilters(pkg.SourceID, opts.ShowFilters) {
 				continue
 			}
 		}
@@ -1362,6 +1476,21 @@ func (ls *ListService) applyAdvancedFiltersToRegistry(items []registry_parser.Re
 			if _, hasUpdate := ls.checkUpdateAvailability(id, installedVer, ""); !hasUpdate {
 				continue
 			}
+		}
+		if opts.OnlyAlwaysTrusted {
+			trusted := false
+			for _, pkg := range installedPackages {
+				if pkg.SourceID == id && pkg.Extras != nil && pkg.Extras.AlwaysTrust {
+					trusted = true
+					break
+				}
+			}
+			if !trusted {
+				continue
+			}
+		}
+		if len(opts.ShowFilters) > 0 && !registryItemMatchesShowFilters(item, opts.ShowFilters) {
+			continue
 		}
 		out = append(out, item)
 	}

--- a/cmd/nvpm/ls_discovery_test.go
+++ b/cmd/nvpm/ls_discovery_test.go
@@ -55,7 +55,7 @@ func runListQuiet(t *testing.T, fn func()) {
 	_, _ = io.Copy(io.Discard, r)
 }
 
-func TestRecordDiscoveryOnRegistryRefreshSkipsWarmCache(t *testing.T) {
+func TestRecordDiscoveryOnWarmCacheLazyRecordsForAvailable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("NVPM_HOME", home)
 	_ = files.GetAppDataPath()
@@ -69,12 +69,19 @@ func TestRecordDiscoveryOnRegistryRefreshSkipsWarmCache(t *testing.T) {
 	showDiscoveryProgress = false
 	showRegistryProgress = false
 
+	// Warm registry cache still lazy-records newer candidates so Available can show "in X days".
 	runListQuiet(t, func() {
 		listDiscoveryTestService(false).ListInstalledPackages(ListQueryOptions{})
 	})
 
-	_, err := os.Stat(filepath.Join(files.GetAppDataPath(), "discovery.json"))
-	assert.True(t, os.IsNotExist(err))
+	b, err := os.ReadFile(filepath.Join(files.GetAppDataPath(), "discovery.json"))
+	require.NoError(t, err)
+	var db struct {
+		FirstSeenUnix map[string]int64 `json:"first_seen_unix"`
+	}
+	require.NoError(t, json.Unmarshal(b, &db))
+	_, ok := db.FirstSeenUnix["npm:eslint@9.0.0"]
+	assert.True(t, ok)
 }
 
 func TestRecordDiscoveryOnRegistryRefreshRecordsAfterRefresh(t *testing.T) {
@@ -379,6 +386,42 @@ func TestDiscoveryDisplayPreferBranchEligibleSoon(t *testing.T) {
 	assert.Empty(t, disc.Eligible)
 	require.Len(t, disc.EligibleSoon, 1)
 	assert.Equal(t, "main (322c79d) in 7 days", disc.EligibleSoon[0])
+}
+
+func TestDiscoveryDisplayNonGitRecordsFirstSeenAndShowsEligibleSoon(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("NVPM_HOME", home)
+	_ = files.GetAppDataPath()
+
+	providers.SetDiscoveryWritesEnabled(true)
+	t.Cleanup(func() { providers.SetDiscoveryWritesEnabled(true) })
+
+	cfg.Flags.MinReleaseAge = 7 * 24 * time.Hour
+	t.Cleanup(func() { cfg.Flags.MinReleaseAge = 0 })
+
+	svc := NewListServiceWithDependencies(
+		&MockLocalPackagesProvider{},
+		&MockRegistryProvider{
+			GetLatestVersionsFunc: func(string) (string, string) { return "4.11.0", "" },
+			GetDataFunc: func(bool) []registry_parser.RegistryItem {
+				return []registry_parser.RegistryItem{{
+					Source:  registry_parser.RegistryItemSource{ID: "npm:eslint"},
+					Version: "4.11.0",
+				}}
+			},
+		},
+		&MockUpdateChecker{},
+		&MockFileDownloader{},
+	)
+
+	disc := svc.discoveryDisplayForInstalled("npm:eslint", "4.10.0", "")
+	require.Len(t, disc.EligibleSoon, 1)
+	assert.Equal(t, "4.11.0 in 7 days", disc.EligibleSoon[0])
+	assert.Equal(t, disc.EligibleSoon, mergedAvailableColumn(disc))
+
+	_, seen, err := providers.GetFirstSeen("npm:eslint", "4.11.0")
+	require.NoError(t, err)
+	assert.True(t, seen)
 }
 
 func TestDiscoveryDisplayRecordsFirstSeenAndShowsEligibleSoon(t *testing.T) {

--- a/cmd/nvpm/ls_test.go
+++ b/cmd/nvpm/ls_test.go
@@ -529,6 +529,31 @@ func TestListInstalledPackagesAdvancedFilters(t *testing.T) {
 		svc.ListInstalledPackages(ListQueryOptions{OnlyOutdated: true, OnlyProviders: []string{"pypi"}})
 	})
 	assert.Contains(t, out4, "No installed packages match")
+
+	out5 := captureOutput(t, func() {
+		svc.ListInstalledPackages(ListQueryOptions{ShowFilters: []string{"categories:*lsp*"}})
+	})
+	assert.Contains(t, out5, "npm:pkg-a")
+	assert.NotContains(t, out5, "pypi:pkg-b")
+}
+
+func TestListInstalledPackagesOnlyAlwaysTrusted(t *testing.T) {
+	mockLocal := &MockLocalPackagesProvider{
+		GetDataFunc: func(force bool) local_packages_parser.LocalPackageRoot {
+			return local_packages_parser.LocalPackageRoot{
+				Packages: []local_packages_parser.LocalPackageItem{
+					{SourceID: "npm:trusted", Version: "1.0.0", Extras: &local_packages_parser.PackageExtras{AlwaysTrust: true}},
+					{SourceID: "npm:normal", Version: "1.0.0"},
+				},
+			}
+		},
+	}
+	svc := NewListServiceWithDependencies(mockLocal, &MockRegistryProvider{}, &MockUpdateChecker{}, &MockFileDownloader{})
+	out := captureOutput(t, func() {
+		svc.ListInstalledPackages(ListQueryOptions{OnlyAlwaysTrusted: true})
+	})
+	assert.Contains(t, out, "npm:trusted")
+	assert.NotContains(t, out, "npm:normal")
 }
 
 func TestListAllPackagesAdvancedFilters(t *testing.T) {
@@ -827,6 +852,8 @@ func TestListCommand(t *testing.T) {
 		assert.NotNil(t, lsCmd.Flags().Lookup("only-outdated"))
 		assert.NotNil(t, lsCmd.Flags().Lookup("only-providers"))
 		assert.NotNil(t, lsCmd.Flags().Lookup("only-categories"))
+		assert.NotNil(t, lsCmd.Flags().Lookup("only-always-trusted"))
+		assert.NotNil(t, lsCmd.Flags().Lookup("filter"))
 	})
 }
 

--- a/cmd/nvpm/package_filter.go
+++ b/cmd/nvpm/package_filter.go
@@ -1,0 +1,313 @@
+package nvpm
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/mistweaverco/nvpm-client/internal/lib/registry_parser"
+	"github.com/spf13/cobra"
+)
+
+// MatchShowJSON returns true when obj matches every filter (AND).
+// Each filter is "[.]path:value". Leading "." is optional. Paths are
+// dot-separated; arrays match if any element matches the remainder.
+// Values use case-insensitive glob semantics (* and ?); without wildcards,
+// matching is exact (after trim). Booleans accept true/false. '*' matches any
+// characters including '/' and ':' (unlike path.Match). The first ':' in a
+// filter separates path from value.
+//
+// Nested fields may be typed Go values from buildPackageInfoJSON
+// (e.g. []map[string]string for git_refs, []string for categories), not only
+// map[string]any / []any - matching uses reflection for maps and slices.
+func MatchShowJSON(obj map[string]any, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	if obj == nil {
+		return false
+	}
+	for _, f := range filters {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		ok, err := matchOneShowFilter(obj, f)
+		if err != nil || !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func matchOneShowFilter(obj map[string]any, filter string) (bool, error) {
+	pathStr, value, err := parseShowFilter(filter)
+	if err != nil {
+		return false, err
+	}
+	segments := splitFilterPath(pathStr)
+	if len(segments) == 0 {
+		return false, fmt.Errorf("empty filter path")
+	}
+	return matchPathValue(obj, segments, value), nil
+}
+
+func parseShowFilter(filter string) (pathStr, value string, err error) {
+	filter = strings.TrimSpace(filter)
+	// Split on the first ':' only so values may contain colons (e.g. package_id:github:owner/repo).
+	idx := strings.Index(filter, ":")
+	if idx <= 0 {
+		return "", "", fmt.Errorf("invalid filter %q (expected path:value)", filter)
+	}
+	pathStr = strings.TrimSpace(filter[:idx])
+	value = strings.TrimSpace(filter[idx+1:])
+	pathStr = strings.TrimPrefix(pathStr, ".")
+	if pathStr == "" {
+		return "", "", fmt.Errorf("empty filter path in %q", filter)
+	}
+	return pathStr, value, nil
+}
+
+func splitFilterPath(p string) []string {
+	parts := strings.Split(p, ".")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func matchPathValue(current any, segments []string, want string) bool {
+	if len(segments) == 0 {
+		return matchLeafValue(current, want)
+	}
+	if current == nil {
+		return false
+	}
+	key := segments[0]
+	rest := segments[1:]
+
+	rv := reflect.ValueOf(current)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		child, ok := lookupReflectMapKeyCI(rv, key)
+		if !ok {
+			return false
+		}
+		return matchPathValue(child, rest, want)
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			if matchPathValue(rv.Index(i).Interface(), segments, want) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func lookupReflectMapKeyCI(rv reflect.Value, key string) (any, bool) {
+	if rv.Kind() != reflect.Map || rv.IsNil() {
+		return nil, false
+	}
+	keyLower := strings.ToLower(key)
+	for _, mk := range rv.MapKeys() {
+		if mk.Kind() != reflect.String {
+			continue
+		}
+		if strings.ToLower(mk.String()) == keyLower {
+			return rv.MapIndex(mk).Interface(), true
+		}
+	}
+	return nil, false
+}
+
+func matchLeafValue(got any, want string) bool {
+	want = strings.TrimSpace(want)
+	if got == nil {
+		return false
+	}
+	switch v := got.(type) {
+	case bool:
+		b, err := strconv.ParseBool(want)
+		if err != nil {
+			return false
+		}
+		return v == b
+	case float64:
+		return matchGlobCI(formatJSONNumber(v), want)
+	case float32:
+		return matchGlobCI(formatJSONNumber(float64(v)), want)
+	case int:
+		return matchGlobCI(strconv.Itoa(v), want)
+	case int64:
+		return matchGlobCI(strconv.FormatInt(v, 10), want)
+	case string:
+		return matchGlobCI(v, want)
+	}
+
+	rv := reflect.ValueOf(got)
+	for rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return false
+		}
+		rv = rv.Elem()
+	}
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			if matchLeafValue(rv.Index(i).Interface(), want) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map:
+		// Nested object without remaining path segments: no scalar match.
+		return false
+	case reflect.String:
+		return matchGlobCI(rv.String(), want)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(want)
+		if err != nil {
+			return false
+		}
+		return rv.Bool() == b
+	default:
+		return matchGlobCI(fmt.Sprint(got), want)
+	}
+}
+
+func formatJSONNumber(f float64) string {
+	if f == float64(int64(f)) {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+func matchGlobCI(got, pattern string) bool {
+	got = strings.ToLower(strings.TrimSpace(got))
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	return matchFilterGlob(got, pattern)
+}
+
+// matchFilterGlob matches shell-like * and ? against the full string.
+// Unlike path.Match, '*' matches any characters including '/' and ':',
+// which is required for package_id values such as github:owner/repo.
+func matchFilterGlob(got, pattern string) bool {
+	return matchFilterGlobAt(got, pattern)
+}
+
+func matchFilterGlobAt(got, pattern string) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			pattern = pattern[1:]
+			if pattern == "" {
+				return true
+			}
+			for i := 0; i <= len(got); i++ {
+				if matchFilterGlobAt(got[i:], pattern) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			if got == "" {
+				return false
+			}
+			got = got[1:]
+			pattern = pattern[1:]
+		default:
+			if got == "" || got[0] != pattern[0] {
+				return false
+			}
+			got = got[1:]
+			pattern = pattern[1:]
+		}
+	}
+	return got == ""
+}
+
+// packageMatchesShowFilters builds show JSON for sourceID and applies filters.
+func packageMatchesShowFilters(sourceID string, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	item := newRegistryParser().GetBySourceId(sourceID)
+	if item.Source.ID == "" {
+		// Not in registry: synthesize a minimal object from lock/sourceID.
+		obj := map[string]any{
+			"package_id": sourceID,
+			"name":       sourceID,
+		}
+		if strings.Contains(sourceID, ":") {
+			parts := strings.SplitN(sourceID, ":", 2)
+			if len(parts) == 2 {
+				obj["provider"] = parts[0]
+			}
+		}
+		if packageAlwaysTrustFromLock(sourceID) {
+			obj["always_trust"] = true
+			obj["status"] = "installed"
+		}
+		return MatchShowJSON(obj, filters)
+	}
+	return MatchShowJSON(buildPackageInfoJSON(item, sourceID), filters)
+}
+
+func registryItemMatchesShowFilters(item registry_parser.RegistryItem, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	sourceID := item.Source.ID
+	return MatchShowJSON(buildPackageInfoJSON(item, sourceID), filters)
+}
+
+// filterSourceIDsByShowFilters keeps source IDs whose show JSON matches all filters.
+func filterSourceIDsByShowFilters(ids []string, filters []string) []string {
+	if len(filters) == 0 {
+		return ids
+	}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if packageMatchesShowFilters(id, filters) {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func getShowFilters(cmd *cobra.Command) []string {
+	if cmd == nil {
+		return nil
+	}
+	filters, err := cmd.Flags().GetStringArray("filter")
+	if err != nil || len(filters) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(filters))
+	for _, f := range filters {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// registerShowFilterFlag adds the shared --filter DSL flag to a command.
+func registerShowFilterFlag(cmd *cobra.Command) {
+	cmd.Flags().StringArray("filter", nil, "Filter by show-JSON field (repeatable AND): [.]path:value with * ? globs")
+}

--- a/cmd/nvpm/package_filter_test.go
+++ b/cmd/nvpm/package_filter_test.go
@@ -1,0 +1,103 @@
+package nvpm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mistweaverco/nvpm-client/internal/lib/registry_parser"
+	"github.com/stretchr/testify/assert"
+)
+
+type emptyRegistryFileReader struct{}
+
+func (emptyRegistryFileReader) ReadFile(string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+
+func TestMatchShowJSONExactAndGlob(t *testing.T) {
+	obj := map[string]any{
+		"name":       "Mistweaver",
+		"package_id": "github:mistweaverco/kulala.nvim",
+		"categories": []any{"Plugin", "HTTP"},
+		"provider":   "github",
+		"status":     "installed",
+	}
+
+	assert.True(t, MatchShowJSON(obj, []string{"categories:Plugin"}))
+	assert.True(t, MatchShowJSON(obj, []string{".categories:Plugin"}))
+	assert.False(t, MatchShowJSON(obj, []string{"categories:*tree*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"categories:*plug*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"package_id:*mistweaverco/*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"package_id:github:mistweaverco*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"package_id:github:mistweaverco/kulala.nvim"}))
+	assert.False(t, MatchShowJSON(obj, []string{"package_id:github:other*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"name:mistweaver"})) // exact after lower
+	assert.False(t, MatchShowJSON(obj, []string{"name:mist"}))      // no glob → exact only
+	assert.True(t, MatchShowJSON(obj, []string{"name:Mist*"}))
+}
+
+func TestParseShowFilterKeepsColonsInValue(t *testing.T) {
+	pathStr, value, err := parseShowFilter("package_id:github:mistweaverco*")
+	assert.NoError(t, err)
+	assert.Equal(t, "package_id", pathStr)
+	assert.Equal(t, "github:mistweaverco*", value)
+}
+
+func TestMatchShowJSONANDAndMissing(t *testing.T) {
+	obj := map[string]any{
+		"provider":     "npm",
+		"package_id":   "npm:eslint",
+		"always_trust": true,
+	}
+	assert.True(t, MatchShowJSON(obj, []string{"provider:npm", "always_trust:true"}))
+	assert.False(t, MatchShowJSON(obj, []string{"provider:npm", "always_trust:false"}))
+	assert.False(t, MatchShowJSON(obj, []string{"missing.path:x"}))
+}
+
+func TestMatchShowJSONNestedArray(t *testing.T) {
+	obj := map[string]any{
+		"git_refs": []any{
+			map[string]any{"ref": "main", "age": "1 day ago"},
+			map[string]any{"ref": "v1.0.0", "age": "120 days ago"},
+		},
+	}
+	assert.True(t, MatchShowJSON(obj, []string{"git_refs.age:1 day ago"}))
+	assert.True(t, MatchShowJSON(obj, []string{"git_refs.ref:v1.0.0"}))
+	assert.False(t, MatchShowJSON(obj, []string{"git_refs.ref:develop"}))
+}
+
+func TestMatchShowJSONTypedSlicesFromBuildPackageInfoJSON(t *testing.T) {
+	// buildPackageInfoJSON / mergeGitDetailsJSON use concrete slice types, not []any.
+	obj := map[string]any{
+		"categories": []string{"Plugin", "Completion"},
+		"git_refs": []map[string]string{
+			{"ref": "main", "commit": "cba53ef", "age": "3 days ago", "kind": "branch"},
+			{"ref": "v1.10.2", "commit": "78336bc", "age": "124 days ago", "kind": "tag"},
+		},
+		"discovery": map[string]string{
+			"remote": "main (cba53ef) committed 3 days ago on remote",
+			"local":  "first recorded locally 2 days ago",
+		},
+	}
+	assert.True(t, MatchShowJSON(obj, []string{"git_refs.age:3 days ago"}))
+	assert.True(t, MatchShowJSON(obj, []string{"git_refs.ref:main"}))
+	assert.True(t, MatchShowJSON(obj, []string{"categories:Plugin"}))
+	assert.True(t, MatchShowJSON(obj, []string{"categories:*complet*"}))
+	assert.True(t, MatchShowJSON(obj, []string{"discovery.remote:*3 days ago*"}))
+	assert.False(t, MatchShowJSON(obj, []string{"git_refs.age:1 day ago"}))
+}
+
+func TestFilterSourceIDsByShowFiltersSynthesized(t *testing.T) {
+	// Empty registry → packageMatchesShowFilters synthesizes provider/package_id.
+	prevRegistry := newRegistryParser
+	newRegistryParser = func() *registry_parser.RegistryParser {
+		return registry_parser.NewRegistryParser(emptyRegistryFileReader{})
+	}
+	defer func() { newRegistryParser = prevRegistry }()
+
+	ids := filterSourceIDsByShowFilters(
+		[]string{"npm:eslint", "pypi:black"},
+		[]string{"provider:npm"},
+	)
+	assert.Equal(t, []string{"npm:eslint"}, ids)
+}

--- a/cmd/nvpm/rm.go
+++ b/cmd/nvpm/rm.go
@@ -95,6 +95,25 @@ Examples:
 			displayIDs = append(displayIDs, displayID)
 		}
 
+		filters := getShowFilters(cmd)
+		if len(filters) > 0 {
+			filteredInternal := make([]string, 0, len(internalIDs))
+			filteredDisplay := make([]string, 0, len(displayIDs))
+			for i, id := range internalIDs {
+				if packageMatchesShowFilters(id, filters) {
+					filteredInternal = append(filteredInternal, id)
+					filteredDisplay = append(filteredDisplay, displayIDs[i])
+				}
+			}
+			internalIDs = filteredInternal
+			displayIDs = filteredDisplay
+		}
+
+		if len(internalIDs) == 0 {
+			fmt.Println("No packages match the current --filter criteria")
+			return
+		}
+
 		// Remove all packages
 		fmt.Printf("Removing %d package(s)...\n", len(internalIDs))
 
@@ -175,6 +194,7 @@ var removeIntegrations []string
 
 func init() {
 	rmCmd.Flags().StringSliceVar(&removeIntegrations, "integrate", nil, "run integration backends cleanup when removing (e.g. --integrate neovim)")
+	registerShowFilterFlag(rmCmd)
 }
 
 // findInstalledPackagesByName searches installed packages for packages matching the given name

--- a/cmd/nvpm/rm_test.go
+++ b/cmd/nvpm/rm_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mistweaverco/nvpm-client/internal/lib/registry_parser"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +23,40 @@ func TestRemoveCommand(t *testing.T) {
 	t.Run("remove command has no subcommands", func(t *testing.T) {
 		assert.Empty(t, rmCmd.Commands())
 	})
+
+	t.Run("rm has filter flag", func(t *testing.T) {
+		assert.NotNil(t, rmCmd.Flags().Lookup("filter"))
+	})
+}
+
+func TestRemoveCommandFiltersSelection(t *testing.T) {
+	prevSupp := isSupportedProviderFn
+	prevRemove := removePackageFn
+	prevRegistry := newRegistryParser
+	isSupportedProviderFn = func(p string) bool { return true }
+	removed := []string{}
+	removePackageFn = func(id string) bool {
+		removed = append(removed, id)
+		return true
+	}
+	newRegistryParser = func() *registry_parser.RegistryParser {
+		return registry_parser.NewRegistryParser(emptyRegistryFileReader{})
+	}
+	defer func() {
+		isSupportedProviderFn = prevSupp
+		removePackageFn = prevRemove
+		newRegistryParser = prevRegistry
+		if sa, ok := rmCmd.Flags().Lookup("filter").Value.(interface{ Replace([]string) error }); ok {
+			_ = sa.Replace(nil)
+		}
+	}()
+
+	_ = rmCmd.Flags().Set("filter", "provider:npm")
+	out := captureOutput(t, func() {
+		rmCmd.Run(rmCmd, []string{"npm:eslint", "pypi:black"})
+	})
+	assert.Contains(t, out, "Removing 1 package")
+	assert.Equal(t, []string{"npm:eslint"}, removed)
 }
 
 func TestRemoveCommandRunPaths(t *testing.T) {

--- a/cmd/nvpm/up.go
+++ b/cmd/nvpm/up.go
@@ -145,6 +145,12 @@ Examples:
 	// Enable shell completion for installed package IDs only.
 	ValidArgsFunction: installedPackageIDCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := validateAlwaysTrustFlags(); err != nil {
+			service := newUpdateService()
+			service.output.Printf("%s %v\n", IconClose(), err)
+			osExit(1)
+			return
+		}
 		forceFlag, _ := cmd.Flags().GetBool("force")
 		providers.SetMinReleaseAgePolicy(providers.MinReleaseAgePolicy{
 			MinAge: cfg.Flags.MinReleaseAge,
@@ -168,7 +174,7 @@ Examples:
 			service := newUpdateService()
 			service.output.Println("Updating all installed packages to latest versions...")
 
-			success := service.UpdateAllPackages()
+			success := service.UpdateAllPackages(getShowFilters(cmd))
 
 			if success {
 				service.output.Println("Successfully updated all packages")
@@ -244,6 +250,26 @@ Examples:
 			displayIDs = append(displayIDs, displayID)
 		}
 
+		filters := getShowFilters(cmd)
+		if len(filters) > 0 {
+			filteredInternal := make([]string, 0, len(internalIDs))
+			filteredDisplay := make([]string, 0, len(displayIDs))
+			for i, id := range internalIDs {
+				if packageMatchesShowFilters(id, filters) {
+					filteredInternal = append(filteredInternal, id)
+					filteredDisplay = append(filteredDisplay, displayIDs[i])
+				}
+			}
+			internalIDs = filteredInternal
+			displayIDs = filteredDisplay
+		}
+
+		if len(internalIDs) == 0 {
+			service := newUpdateService()
+			service.output.Println("No packages match the current --filter criteria")
+			return
+		}
+
 		// Update individual packages
 		service := newUpdateService()
 		service.output.Printf("Updating %d package(s) to latest versions...\n", len(internalIDs))
@@ -262,6 +288,7 @@ Examples:
 				allSuccess = false
 				continue
 			}
+			applyPendingAlwaysTrust(internalID)
 
 			// Update the package with spinner showing package name
 			var success bool
@@ -275,6 +302,7 @@ Examples:
 				failedCount++
 				allSuccess = false
 				clearPendingUpdateResolution(internalID)
+				clearPendingAlwaysTrust(internalID)
 				continue
 			}
 
@@ -282,6 +310,7 @@ Examples:
 				service.output.Printf("%s Successfully updated %s\n", IconCheck(), displayID)
 				successCount++
 				persistUpdateResolutionAfterInstall(internalID)
+				persistAlwaysTrustAfterInstall(internalID)
 			} else {
 				service.output.Printf("%s Failed to update %s\n", IconClose(), displayID)
 				if detail := strings.TrimSpace(providers.TakeLastError()); detail != "" {
@@ -290,6 +319,7 @@ Examples:
 				failedCount++
 				allSuccess = false
 				clearPendingUpdateResolution(internalID)
+				clearPendingAlwaysTrust(internalID)
 			}
 		}
 
@@ -310,7 +340,10 @@ func init() {
 	upCmd.Flags().BoolP("all", "A", false, "Update all installed packages to their latest versions")
 	upCmd.Flags().Bool("self", false, "Update nvpm itself to the latest version")
 	upCmd.Flags().Bool("force", false, "bypass min-release-age safety checks")
+	upCmd.Flags().BoolVar(&installAlwaysTrust, "always-trust", false, "persistently skip min-release-age for this package (stored in lock extras.always_trust)")
+	upCmd.Flags().BoolVar(&installNoAlwaysTrust, "no-always-trust", false, "clear extras.always_trust for this package")
 	upCmd.Flags().StringVar(&installUpdateResolution, "update-resolution", "", "git-only: override update-resolution when updating (e.g. always, release-age-gap:30d)")
+	registerShowFilterFlag(upCmd)
 }
 
 // newUpdateService is a factory to allow test injection
@@ -319,7 +352,11 @@ var newUpdateService = NewUpdateService
 // UpdateAllPackages updates all installed packages to their latest versions
 // Only updates packages that have updates available according to the registry data
 // (or cached remote_latest for non-registry git packages).
-func (us *UpdateService) UpdateAllPackages() bool {
+func (us *UpdateService) UpdateAllPackages(showFilters ...[]string) bool {
+	var filters []string
+	if len(showFilters) > 0 {
+		filters = showFilters[0]
+	}
 	// Refresh registry and discover non-registry git remotes when the snapshot was rebuilt.
 	refreshed, _ := downloadAndUnzipRegistryFn()
 	us.registry.GetData(refreshed)
@@ -345,6 +382,10 @@ func (us *UpdateService) UpdateAllPackages() bool {
 	skippedCount := 0
 
 	for _, pkg := range localPackages {
+		if len(filters) > 0 && !packageMatchesShowFilters(pkg.SourceID, filters) {
+			skippedCount++
+			continue
+		}
 		hasUpdate := us.checkUpdateAvailability(pkg.SourceID, pkg.Version, pkg.Commit)
 		if hasUpdate {
 			packagesToUpdate = append(packagesToUpdate, pkg)
@@ -365,6 +406,14 @@ func (us *UpdateService) UpdateAllPackages() bool {
 	failedCount := 0
 
 	for _, pkg := range packagesToUpdate {
+		if err := applyPendingUpdateResolution(pkg.SourceID); err != nil {
+			us.output.Printf("%s Invalid --update-resolution: %v\n", IconClose(), err)
+			failedCount++
+			allSuccess = false
+			continue
+		}
+		applyPendingAlwaysTrust(pkg.SourceID)
+
 		// Update the package with spinner showing package name
 		var success bool
 		action := func() {
@@ -376,12 +425,16 @@ func (us *UpdateService) UpdateAllPackages() bool {
 			us.output.Printf("%s Failed to update %s: %v\n", IconClose(), pkg.SourceID, err)
 			failedCount++
 			allSuccess = false
+			clearPendingUpdateResolution(pkg.SourceID)
+			clearPendingAlwaysTrust(pkg.SourceID)
 			continue
 		}
 
 		if success {
 			successCount++
 			us.output.Printf("%s Successfully updated %s\n", IconCheck(), pkg.SourceID)
+			persistUpdateResolutionAfterInstall(pkg.SourceID)
+			persistAlwaysTrustAfterInstall(pkg.SourceID)
 		} else {
 			failedCount++
 			us.output.Printf("%s Failed to update %s\n", IconClose(), pkg.SourceID)
@@ -389,6 +442,8 @@ func (us *UpdateService) UpdateAllPackages() bool {
 				us.output.Printf("  %s\n", detail)
 			}
 			allSuccess = false
+			clearPendingUpdateResolution(pkg.SourceID)
+			clearPendingAlwaysTrust(pkg.SourceID)
 		}
 	}
 

--- a/cmd/nvpm/up_test.go
+++ b/cmd/nvpm/up_test.go
@@ -237,6 +237,12 @@ func TestUpdateCommand(t *testing.T) {
 		assert.Equal(t, "A", allFlag.Shorthand)
 		assert.Equal(t, "Update all installed packages to their latest versions", allFlag.Usage)
 	})
+
+	t.Run("update command has always-trust and filter flags", func(t *testing.T) {
+		assert.NotNil(t, upCmd.Flags().Lookup("always-trust"))
+		assert.NotNil(t, upCmd.Flags().Lookup("no-always-trust"))
+		assert.NotNil(t, upCmd.Flags().Lookup("filter"))
+	})
 }
 
 func TestUpdateCommandRunPaths(t *testing.T) {

--- a/internal/lib/local_packages_parser/local_packages_parser_test.go
+++ b/internal/lib/local_packages_parser/local_packages_parser_test.go
@@ -531,6 +531,44 @@ func TestLocalPackagesParserWithMock(t *testing.T) {
 			assert.Equal(t, KindNeovimPlugin, saved.Packages[0].Extras.Kind)
 		}
 	})
+
+	t.Run("merge package always_trust sets and clears", func(t *testing.T) {
+		existingData := LocalPackageRoot{
+			Packages: []LocalPackageItem{
+				{SourceID: "npm:eslint", Version: "9.0.0"},
+			},
+		}
+		jsonData, _ := json.Marshal(existingData)
+
+		var written []byte
+		mockFileManager := &MockFileManager{
+			GetAppLocalPackagesFilePathFunc: func() string { return "/mock/path/local-packages.json" },
+			FileExistsFunc:                  func(path string) bool { return true },
+			ReadFileFunc: func(path string) ([]byte, error) {
+				if written != nil {
+					return written, nil
+				}
+				return jsonData, nil
+			},
+			WriteFileFunc: func(path string, data []byte, perm uint32) error { written = data; return nil },
+		}
+
+		parser := NewWithFileManager(mockFileManager)
+		err := parser.MergePackageAlwaysTrust("npm:eslint", true)
+		assert.NoError(t, err)
+
+		var saved LocalPackageRoot
+		_ = json.Unmarshal(written, &saved)
+		if assert.NotNil(t, saved.Packages[0].Extras) {
+			assert.True(t, saved.Packages[0].Extras.AlwaysTrust)
+		}
+
+		err = parser.MergePackageAlwaysTrust("npm:eslint", false)
+		assert.NoError(t, err)
+		saved = LocalPackageRoot{}
+		_ = json.Unmarshal(written, &saved)
+		assert.Nil(t, saved.Packages[0].Extras)
+	})
 }
 
 func TestMockFileManager(t *testing.T) {

--- a/internal/lib/local_packages_parser/root.go
+++ b/internal/lib/local_packages_parser/root.go
@@ -39,6 +39,8 @@ type PackageExtras struct {
 	TreeSitterExternalQueries []TreeSitterExternalQueryPin `json:"treesitter_external_queries,omitempty"`
 	// UpdateResolution overrides global git update-resolution for this package.
 	UpdateResolution *LockUpdateResolution `json:"update_resolution,omitempty"`
+	// AlwaysTrust skips min-release-age for this package on add/up (persisted; unlike --force).
+	AlwaysTrust bool `json:"always_trust,omitempty"`
 }
 
 // LockUpdateResolution mirrors config git.update-resolution for lock file persistence.
@@ -553,6 +555,54 @@ func (lpp *LocalPackagesParser) MergePackageUpdateResolution(sourceID string, re
 	return nil
 }
 
+// MergePackageAlwaysTrust sets or clears extras.always_trust for an installed package.
+func (lpp *LocalPackagesParser) MergePackageAlwaysTrust(sourceID string, trust bool) error {
+	sourceID = normalizePackageID(sourceID)
+	if sourceID == "" {
+		return nil
+	}
+	root := lpp.GetData(false)
+	for i := range root.Packages {
+		if root.Packages[i].SourceID != sourceID {
+			continue
+		}
+		if trust {
+			if root.Packages[i].Extras == nil {
+				root.Packages[i].Extras = &PackageExtras{}
+			}
+			root.Packages[i].Extras.AlwaysTrust = true
+		} else if root.Packages[i].Extras != nil {
+			root.Packages[i].Extras.AlwaysTrust = false
+			if packageExtrasEmpty(root.Packages[i].Extras) {
+				root.Packages[i].Extras = nil
+			}
+		} else {
+			return nil
+		}
+		root.Schema = lockSchemaURL
+		localPackagesFile := lpp.fileManager.GetAppLocalPackagesFilePath()
+		jsonData, err := marshalIndent(root, "", "  ")
+		if err != nil {
+			return err
+		}
+		return lpp.fileManager.WriteFile(localPackagesFile, jsonData, 0644)
+	}
+	return nil
+}
+
+func packageExtrasEmpty(e *PackageExtras) bool {
+	if e == nil {
+		return true
+	}
+	return e.Kind == "" &&
+		len(e.Integrations) == 0 &&
+		len(e.TreeSitterParserChoices) == 0 &&
+		len(e.TreeSitterQueryChoices) == 0 &&
+		len(e.TreeSitterExternalQueries) == 0 &&
+		e.UpdateResolution == nil &&
+		!e.AlwaysTrust
+}
+
 func (lpp *LocalPackagesParser) IsNeovimPlugin(sourceID string) bool {
 	item := lpp.GetBySourceId(sourceID)
 	return item.Extras != nil && item.Extras.Kind == KindNeovimPlugin
@@ -708,6 +758,10 @@ func MergePackageKind(sourceId, kind string) error {
 
 func MergePackageUpdateResolution(sourceId string, resolution *LockUpdateResolution) error {
 	return globalParser.MergePackageUpdateResolution(sourceId, resolution)
+}
+
+func MergePackageAlwaysTrust(sourceId string, trust bool) error {
+	return globalParser.MergePackageAlwaysTrust(sourceId, trust)
 }
 
 func IsNeovimPlugin(sourceId string) bool {

--- a/internal/lib/providers/always_trust.go
+++ b/internal/lib/providers/always_trust.go
@@ -1,0 +1,35 @@
+package providers
+
+import (
+	"strings"
+
+	"github.com/mistweaverco/nvpm-client/internal/lib/local_packages_parser"
+)
+
+// pendingAlwaysTrust holds per-package always_trust set by add/up before the lock is written.
+var pendingAlwaysTrust = map[string]bool{}
+
+// SetPendingAlwaysTrust registers a one-shot always_trust override for sourceID during install.
+func SetPendingAlwaysTrust(sourceID string, trust bool) {
+	sourceID = strings.TrimSpace(sourceID)
+	if sourceID == "" {
+		return
+	}
+	pendingAlwaysTrust[sourceID] = trust
+}
+
+// ClearPendingAlwaysTrust removes a pending always_trust override after install completes.
+func ClearPendingAlwaysTrust(sourceID string) {
+	delete(pendingAlwaysTrust, strings.TrimSpace(sourceID))
+}
+
+// PackageAlwaysTrust reports whether sourceID should skip min-release-age.
+// Priority: pending CLI override → lock extras.always_trust.
+func PackageAlwaysTrust(sourceID string) bool {
+	sourceID = strings.TrimSpace(sourceID)
+	if trust, ok := pendingAlwaysTrust[sourceID]; ok {
+		return trust
+	}
+	item := local_packages_parser.GetBySourceId(sourceID)
+	return item.Extras != nil && item.Extras.AlwaysTrust
+}

--- a/internal/lib/providers/always_trust_test.go
+++ b/internal/lib/providers/always_trust_test.go
@@ -1,0 +1,32 @@
+package providers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnforceMinReleaseAgeBypassedByPendingAlwaysTrust(t *testing.T) {
+	_ = withTempNvpmHome(t)
+
+	SetMinReleaseAgePolicy(MinReleaseAgePolicy{MinAge: 7 * 24 * time.Hour})
+	t.Cleanup(func() {
+		SetMinReleaseAgePolicy(MinReleaseAgePolicy{MinAge: 0})
+		ClearPendingAlwaysTrust("npm:eslint")
+	})
+
+	SetDiscoveryWritesEnabled(true)
+	require.NoError(t, RecordDiscoveryBatch([]DiscoveryPair{{
+		SourceID: "npm:eslint",
+		Version:  "9.0.0",
+	}}))
+
+	err := enforceMinReleaseAge("npm:eslint", "9.0.0")
+	require.Error(t, err)
+
+	SetPendingAlwaysTrust("npm:eslint", true)
+	err = enforceMinReleaseAge("npm:eslint", "9.0.0")
+	assert.NoError(t, err)
+}

--- a/internal/lib/providers/root.go
+++ b/internal/lib/providers/root.go
@@ -51,6 +51,9 @@ func enforceMinReleaseAge(sourceID, version string) error {
 	if p.BypassAll || p.Force || p.MinAge <= 0 {
 		return nil
 	}
+	if PackageAlwaysTrust(sourceID) {
+		return nil
+	}
 	if version == "" || version == "latest" {
 		// We only gate concrete versions.
 		return nil

--- a/schemas/lock.schema.json
+++ b/schemas/lock.schema.json
@@ -159,6 +159,10 @@
                     }
                   }
                 }
+              },
+              "always_trust": {
+                "type": "boolean",
+                "description": "When true, skip min-release-age for this package on install/update. Unlike --force, this persists in the lock file."
               }
             }
           }


### PR DESCRIPTION
`filter` works like this:

```
nvpm ls --filter 'git_refs.age:2 day* ago' --filter 'package_id:github:mistweaverco*'
```

You can filter on all fields in `nvpm show -o json <package_id>`, and you can use `*` as a wildcard.
You can also use `--filter` multiple times to combine filters.

`always-trust` works like this:

```
nvpm add --always-trust <package_id>
nvpm up --always-trust <package_id1> <package_id2>
```

Untrust an already trusted package with:

```
nvpm up --no-always-trust <package_id>
```