### PR TITLE
fix(providers): always prefer default_version from registry

### DIFF
--- a/internal/lib/providers/codeberg_provider.go
+++ b/internal/lib/providers/codeberg_provider.go
@@ -137,8 +137,8 @@ func (p *CodebergProvider) installFromRelease(sourceID, repo, version string, re
 	// Resolve version
 	resolvedVersion := version
 	if resolvedVersion == "" || resolvedVersion == "latest" {
-		resolvedVersion = registryItem.Version
-		if resolvedVersion == "" {
+		resolvedVersion = registryItem.VersionForRequestedRef(resolvedVersion)
+		if resolvedVersion == "" || resolvedVersion == "latest" {
 			// Try to get latest release from Codeberg API
 			latestTag, err := p.getLatestReleaseTag(repo)
 			if err != nil {
@@ -256,12 +256,15 @@ func (p *CodebergProvider) installFromGit(sourceID, repo, version string) bool {
 	resolvedVersion := version
 	lockedCheckout := strings.TrimSpace(GetLockedCommit()) != ""
 	if !lockedCheckout && (resolvedVersion == "" || resolvedVersion == "latest") {
-		// Try to get latest tag from the cloned repo
-		var err error
-		resolvedVersion, err = ResolveGitLatestRef(sourceID)
-		if err != nil || strings.TrimSpace(resolvedVersion) == "" {
-			Logger.Info(fmt.Sprintf("Codeberg Install: Could not determine latest version, using default branch: %v", err))
-			resolvedVersion = p.getDefaultBranch(repo, repoPath)
+		if pin := resolveOmittedOrLatestFromRegistry(sourceID, resolvedVersion); pin != "" && pin != "latest" {
+			resolvedVersion = pin
+		} else {
+			var err error
+			resolvedVersion, err = ResolveGitLatestRef(sourceID)
+			if err != nil || strings.TrimSpace(resolvedVersion) == "" {
+				Logger.Info(fmt.Sprintf("Codeberg Install: Could not determine latest version, using default branch: %v", err))
+				resolvedVersion = p.getDefaultBranch(repo, repoPath)
+			}
 		}
 	}
 

--- a/internal/lib/providers/generic_provider.go
+++ b/internal/lib/providers/generic_provider.go
@@ -92,7 +92,7 @@ func (p *GenericProvider) Install(sourceID, version string) bool {
 	// Resolve version
 	resolvedVersion := version
 	if resolvedVersion == "" || resolvedVersion == "latest" {
-		resolvedVersion = registryItem.Version
+		resolvedVersion = registryItem.VersionForRequestedRef(resolvedVersion)
 		if resolvedVersion == "" {
 			resolvedVersion = "latest"
 		}

--- a/internal/lib/providers/github_provider.go
+++ b/internal/lib/providers/github_provider.go
@@ -165,8 +165,8 @@ func (p *GitHubProvider) installFromRelease(sourceID, repo, version string, regi
 	}
 
 	if resolvedVersion == "" || resolvedVersion == "latest" {
-		resolvedVersion = registryItem.Version
-		if resolvedVersion == "" {
+		resolvedVersion = registryItem.VersionForRequestedRef(resolvedVersion)
+		if resolvedVersion == "" || resolvedVersion == "latest" {
 			// Try to get latest release from GitHub API
 			latestTag, err := p.getLatestReleaseTag(repo)
 			if err != nil {

--- a/internal/lib/providers/github_treesitter_phased_install.go
+++ b/internal/lib/providers/github_treesitter_phased_install.go
@@ -259,11 +259,15 @@ func (p *GitHubProvider) gitCloneAndCheckout(sourceID, repo, version string) (re
 	resolvedVersion = version
 	lockedCheckout := strings.TrimSpace(GetLockedCommit()) != ""
 	if !lockedCheckout && (resolvedVersion == "" || resolvedVersion == "latest") {
-		var err error
-		resolvedVersion, err = ResolveGitLatestRef(sourceID)
-		if err != nil || strings.TrimSpace(resolvedVersion) == "" {
-			Logger.Info(fmt.Sprintf("GitHub Install: Could not determine latest version, using default branch: %v", err))
-			resolvedVersion = p.getDefaultBranch(repo, repoPath)
+		if pin := resolveOmittedOrLatestFromRegistry(sourceID, resolvedVersion); pin != "" && pin != "latest" {
+			resolvedVersion = pin
+		} else {
+			var err error
+			resolvedVersion, err = ResolveGitLatestRef(sourceID)
+			if err != nil || strings.TrimSpace(resolvedVersion) == "" {
+				Logger.Info(fmt.Sprintf("GitHub Install: Could not determine latest version, using default branch: %v", err))
+				resolvedVersion = p.getDefaultBranch(repo, repoPath)
+			}
 		}
 	}
 

--- a/internal/lib/providers/gitlab_provider.go
+++ b/internal/lib/providers/gitlab_provider.go
@@ -140,8 +140,8 @@ func (p *GitLabProvider) installFromRelease(sourceID, repo, version string, regi
 	// Resolve version
 	resolvedVersion := version
 	if resolvedVersion == "" || resolvedVersion == "latest" {
-		resolvedVersion = registryItem.Version
-		if resolvedVersion == "" {
+		resolvedVersion = registryItem.VersionForRequestedRef(resolvedVersion)
+		if resolvedVersion == "" || resolvedVersion == "latest" {
 			// Try to get latest release from GitLab API
 			latestTag, err := p.getLatestReleaseTag(repo)
 			if err != nil {
@@ -262,12 +262,15 @@ func (p *GitLabProvider) installFromGit(sourceID, repo, version string) bool {
 	resolvedVersion := version
 	lockedCheckout := strings.TrimSpace(GetLockedCommit()) != ""
 	if !lockedCheckout && (resolvedVersion == "" || resolvedVersion == "latest") {
-		// Try to get latest tag from the cloned repo
-		var err error
-		resolvedVersion, err = ResolveGitLatestRef(sourceID)
-		if err != nil || strings.TrimSpace(resolvedVersion) == "" {
-			Logger.Info(fmt.Sprintf("GitLab Install: Could not determine latest version, using default branch: %v", err))
-			resolvedVersion = p.getDefaultBranch(repo, repoPath)
+		if pin := resolveOmittedOrLatestFromRegistry(sourceID, resolvedVersion); pin != "" && pin != "latest" {
+			resolvedVersion = pin
+		} else {
+			var err error
+			resolvedVersion, err = ResolveGitLatestRef(sourceID)
+			if err != nil || strings.TrimSpace(resolvedVersion) == "" {
+				Logger.Info(fmt.Sprintf("GitLab Install: Could not determine latest version, using default branch: %v", err))
+				resolvedVersion = p.getDefaultBranch(repo, repoPath)
+			}
 		}
 	}
 

--- a/internal/lib/providers/openvsx_provider.go
+++ b/internal/lib/providers/openvsx_provider.go
@@ -95,8 +95,8 @@ func (p *OpenVSXProvider) Install(sourceID, version string) bool {
 	// Resolve version
 	resolvedVersion := version
 	if resolvedVersion == "" || resolvedVersion == "latest" {
-		resolvedVersion = registryItem.Version
-		if resolvedVersion == "" {
+		resolvedVersion = registryItem.VersionForRequestedRef(resolvedVersion)
+		if resolvedVersion == "" || resolvedVersion == "latest" {
 			// Try to get latest version from OpenVSX API
 			latestVersion, err := p.getLatestVersion(repo)
 			if err != nil {

--- a/internal/lib/providers/root.go
+++ b/internal/lib/providers/root.go
@@ -349,24 +349,19 @@ func ResolveVersion(sourceId string, version string) (string, error) {
 		return version, nil
 	}
 
-	// Prefer the registry version when present for both:
-	// - version == "" (user omitted a version)
-	// - version == "latest" (user asked for "latest")
-	//
-	// This keeps installs consistent with the curated registry, instead of always
-	// deferring to provider "latest" logic (e.g. GitHub release/tag lookups).
-	if version == "" || version == "latest" {
-		registry := registry_parser.NewDefaultRegistryParser()
-		registryItem := registry.GetBySourceId(sourceId)
-		if registryItem.Version != "" {
-			return registryItem.Version, nil
-		}
+	registry := registry_parser.NewDefaultRegistryParser()
+	registryItem := registry.GetBySourceId(sourceId)
 
-		// Non-registry git packages: prefer-branch-over-release via remote discovery.
-		if IsGitHostedSourceID(sourceId) {
-			if ref, err := ResolveGitLatestRef(sourceId); err == nil && strings.TrimSpace(ref) != "" {
-				return strings.TrimSpace(ref), nil
-			}
+	// Omitted @version: default_version always wins over discovered latest / git tips.
+	// Explicit @latest still uses the discovered registry Version field.
+	if resolved := registryItem.VersionForRequestedRef(version); resolved != "" && resolved != "latest" {
+		return resolved, nil
+	}
+
+	// No registry pin or version: git-hosted packages use prefer-branch-over-release.
+	if IsGitHostedSourceID(sourceId) {
+		if ref, err := ResolveGitLatestRef(sourceId); err == nil && strings.TrimSpace(ref) != "" {
+			return strings.TrimSpace(ref), nil
 		}
 	}
 
@@ -405,11 +400,8 @@ func ResolveVersion(sourceId string, version string) (string, error) {
 	case ProviderOpenVSX:
 		pkgManager = getOpenVSXProvider()
 	case ProviderGeneric:
-		// Generic provider gets version from registry
-		registry := registry_parser.NewDefaultRegistryParser()
-		registryItem := registry.GetBySourceId(sourceId)
-		if registryItem.Version != "" {
-			return registryItem.Version, nil
+		if resolved := registryItem.VersionForRequestedRef(version); resolved != "" {
+			return resolved, nil
 		}
 		return "latest", nil
 	case ProviderUnsupported:
@@ -427,6 +419,13 @@ func ResolveVersion(sourceId string, version string) (string, error) {
 	}
 
 	return version, nil
+}
+
+// resolveOmittedOrLatestFromRegistry maps an empty/"latest" version onto registry data.
+// An omitted version prefers default_version; "latest" uses the discovered Version field.
+func resolveOmittedOrLatestFromRegistry(sourceID, version string) string {
+	item := registry_parser.NewDefaultRegistryParser().GetBySourceId(sourceID)
+	return item.VersionForRequestedRef(version)
 }
 
 func Install(sourceId string, version string) bool {

--- a/internal/lib/providers/root_test.go
+++ b/internal/lib/providers/root_test.go
@@ -65,3 +65,57 @@ func TestResolveVersionUsesRegistryVersionWhenOmitted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "v1.0.0", got)
 }
+
+func TestResolveVersionPrefersDefaultVersionWhenOmitted(t *testing.T) {
+	_ = withTempNvpmHome(t)
+	sourceID := "github:microsoft/vscode-js-debug"
+	writeRegistry(t, []registry_parser.RegistryItem{{
+		Name:           "js-debug-adapter",
+		Version:        "v9.9.9",
+		DefaultVersion: "v1.117.0",
+		Source:         registry_parser.RegistryItemSource{ID: sourceID},
+	}})
+
+	oldDiscover := discoverGitRemoteLatestFn
+	t.Cleanup(func() { discoverGitRemoteLatestFn = oldDiscover })
+	discoverGitRemoteLatestFn = func(string, string) (GitRemoteLatestResult, error) {
+		t.Fatal("default_version must skip remote latest discovery")
+		return GitRemoteLatestResult{}, errors.New("should not discover")
+	}
+
+	got, err := ResolveVersion(sourceID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.117.0", got)
+
+	got, err = ResolveVersion(sourceID, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, "v9.9.9", got)
+
+	got, err = ResolveVersion(sourceID, "v1.76.1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.76.1", got)
+}
+
+func TestResolveVersionPrefersNestedSourceDefaultVersionWhenOmitted(t *testing.T) {
+	_ = withTempNvpmHome(t)
+	sourceID := "github:microsoft/vscode-js-debug"
+	writeRegistry(t, []registry_parser.RegistryItem{{
+		Name:    "js-debug-adapter",
+		Version: "v9.9.9",
+		Source: registry_parser.RegistryItemSource{
+			ID:             sourceID,
+			DefaultVersion: "v1.117.0",
+		},
+	}})
+
+	oldDiscover := discoverGitRemoteLatestFn
+	t.Cleanup(func() { discoverGitRemoteLatestFn = oldDiscover })
+	discoverGitRemoteLatestFn = func(string, string) (GitRemoteLatestResult, error) {
+		t.Fatal("source.default_version must skip remote latest discovery")
+		return GitRemoteLatestResult{}, errors.New("should not discover")
+	}
+
+	got, err := ResolveVersion(sourceID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.117.0", got)
+}

--- a/internal/lib/registry_parser/registry_parser_test.go
+++ b/internal/lib/registry_parser/registry_parser_test.go
@@ -329,6 +329,28 @@ func TestGetBySourceId(t *testing.T) {
 		item := parser.GetBySourceId("github:tree-sitter/tree-sitter-regex")
 		assert.Equal(t, "v0.25.0", item.Version)
 		assert.Equal(t, "v0.25.0", item.DefaultVersion)
+		assert.Equal(t, "v0.25.0", item.PinForOmittedVersion())
+	})
+
+	t.Run("unmarshals nested source.default_version", func(t *testing.T) {
+		mockReader := &mockFileReader{}
+		parser := NewRegistryParser(mockReader)
+
+		jsonData := `[
+			{"name": "js-debug-adapter", "version": "v9.9.9", "source": {"id": "github:microsoft/vscode-js-debug", "default_version": "v1.117.0"}}
+		]`
+
+		err := parser.LoadFromBytes([]byte(jsonData))
+		require.NoError(t, err)
+
+		item := parser.GetBySourceId("github:microsoft/vscode-js-debug")
+		assert.Equal(t, "v9.9.9", item.Version)
+		assert.Equal(t, "", item.DefaultVersion)
+		assert.Equal(t, "v1.117.0", item.Source.DefaultVersion)
+		assert.Equal(t, "v1.117.0", item.PinForOmittedVersion())
+		assert.Equal(t, "v1.117.0", item.VersionForRequestedRef(""))
+		assert.Equal(t, "v9.9.9", item.VersionForRequestedRef("latest"))
+		assert.Equal(t, "v1.76.1", item.VersionForRequestedRef("v1.76.1"))
 	})
 
 	t.Run("returns empty item when source ID not found", func(t *testing.T) {

--- a/internal/lib/registry_parser/root.go
+++ b/internal/lib/registry_parser/root.go
@@ -160,11 +160,14 @@ func (d *RegistryItemSourceDownloadList) UnmarshalJSON(data []byte) error {
 }
 
 type RegistryItemSource struct {
-	ID            string                         `json:"id"`
-	Asset         RegistryItemSourceAssetList    `json:"asset,omitempty"`
-	Download      RegistryItemSourceDownloadList `json:"download,omitempty"`
-	Bin           string                         `json:"bin,omitempty"`
-	ExtraPackages []string                       `json:"extra_packages,omitempty"`
+	ID string `json:"id"`
+	// DefaultVersion is accepted when older registry JSON nested the pin under source
+	// instead of the package root. Prefer RegistryItem.DefaultVersion.
+	DefaultVersion string                         `json:"default_version,omitempty"`
+	Asset          RegistryItemSourceAssetList    `json:"asset,omitempty"`
+	Download       RegistryItemSourceDownloadList `json:"download,omitempty"`
+	Bin            string                         `json:"bin,omitempty"`
+	ExtraPackages  []string                       `json:"extra_packages,omitempty"`
 }
 
 // RegistryItemTreeSitterExternalQueries points at a separate repository that only
@@ -324,6 +327,35 @@ type RegistryItem struct {
 	Requires          *RegistryItemRequires    `json:"requires,omitempty"`
 	PostInstall       *RegistryItemPostInstall `json:"post_install,omitempty"`
 	Git               *RegistryItemGit         `json:"git,omitempty"`
+}
+
+// PinForOmittedVersion is the curated install pin when the user did not pass @tag.
+// Top-level default_version always wins; source.default_version is accepted for
+// older registry JSON that nested the field.
+func (item RegistryItem) PinForOmittedVersion() string {
+	if v := strings.TrimSpace(item.DefaultVersion); v != "" {
+		return v
+	}
+	return strings.TrimSpace(item.Source.DefaultVersion)
+}
+
+// VersionForRequestedRef maps a user-facing version argument onto registry data.
+// An omitted version (empty) always prefers default_version. "latest" uses the
+// discovered Version field and ignores the pin. Any other explicit ref is returned as-is.
+func (item RegistryItem) VersionForRequestedRef(requested string) string {
+	requested = strings.TrimSpace(requested)
+	if requested != "" && !strings.EqualFold(requested, "latest") {
+		return requested
+	}
+	if requested == "" {
+		if pin := item.PinForOmittedVersion(); pin != "" {
+			return pin
+		}
+	}
+	if v := strings.TrimSpace(item.Version); v != "" {
+		return v
+	}
+	return requested
 }
 
 type RegistryRoot []RegistryItem


### PR DESCRIPTION
Always prefer default_version via registry data, unless the user added an explicit version via `pkgid@v1.2.3`.